### PR TITLE
Disable assertion checking

### DIFF
--- a/Makefile.include
+++ b/Makefile.include
@@ -9,7 +9,7 @@ OBJDUMP = $(PREFIX)objdump
 FLASH   = st-flash
 OPENOCD = openocd
 
-OPTFLAGS  = -Os -g
+OPTFLAGS  = -Os -g -DNDEBUG
 
 CFLAGS   += $(OPTFLAGS) \
             -W \


### PR DESCRIPTION
The trezor-crypto code has some assertions, which are enabled unless
compiled with -DNDEBUG.  This does not make much sense for the Trezor
as could not write the assertion errors to stderr anyway.

This simple patch removes the dependency to assert, printf, etc. It
saves about 11kb flash and 2.2kb ram.