### PR TITLE
PIN handling - constant time.

### DIFF
--- a/firmware/protect.c
+++ b/firmware/protect.c
@@ -156,16 +156,16 @@ bool protectPin(bool use_cached)
 			delay(10000000);
 		}
 	}
-	storage_increasePinFails();
-	bool increase_failed = (fails >= storage_getPinFails());
 	const char *pin;
 	pin = requestPin(PinMatrixRequestType_PinMatrixRequestType_Current, "Please enter current PIN:");
 	if (!pin) {
 		fsm_sendFailure(FailureType_Failure_PinCancelled, "PIN Cancelled");
 		return false;
 	}
+	storage_increasePinFails();
+	bool increase_failed = (fails >= storage_getPinFails());
 	if (storage_isPinCorrect(pin) && !increase_failed) {
-		session_cachePin(pin);
+		session_cachePin();
 		storage_resetPinFails();
 		return true;
 	} else {

--- a/firmware/storage.h
+++ b/firmware/storage.h
@@ -52,7 +52,7 @@ bool session_isPassphraseCached(void);
 bool storage_isPinCorrect(const char *pin);
 bool storage_hasPin(void);
 void storage_setPin(const char *pin);
-void session_cachePin(const char *pin);
+void session_cachePin(void);
 bool session_isPinCached(void);
 void storage_resetPinFails(void);
 void storage_increasePinFails(void);


### PR DESCRIPTION
This diff contains three changes.
1. Make timing isPinCorrect independent of storage.pin, to avoid timing attacks
2. Only update failed PIN counter if the user entered a PIN.
   Of course, the fail counter is still incremented, before the PIN is checked.
3. Don't cache the PIN, but just the fact that the PIN was entered.  The
   cache should be in sync with storage.pin in any case.
