### PR TITLE
New usbDelay that delays and handles USB requests

### DIFF
--- a/firmware/protect.c
+++ b/firmware/protect.c
@@ -57,7 +57,7 @@ bool protectButton(ButtonRequestType type, bool confirm_only)
 
 		// button acked - check buttons
 		if (acked) {
-			delay(100000);
+			usbDelay(3500);
 			buttonUpdate();
 			if (button.YesUp) {
 				result = true;
@@ -165,7 +165,7 @@ bool protectPin(bool use_cached)
 			}
 			layoutDialog(DIALOG_ICON_INFO, NULL, NULL, NULL, "Wrong PIN entered", NULL, "Please wait", secstr, "to continue ...", NULL);
 			// wait one second
-			delay(24000000);
+			usbDelay(840000);
 		}
 	}
 	const char *pin;

--- a/firmware/usb.c
+++ b/firmware/usb.c
@@ -332,3 +332,10 @@ void usbTiny(char set)
 {
 	tiny = set;
 }
+
+void usbDelay(int cycles)
+{
+	while (cycles--) {
+		usbd_poll(usbd_dev);
+	}
+}

--- a/firmware/usb.h
+++ b/firmware/usb.h
@@ -24,5 +24,6 @@ void usbInit(void);
 void usbPoll(void);
 void usbReconnect(void);
 void usbTiny(char set);
+void usbDelay(int cycles);
 
 #endif


### PR DESCRIPTION
Added usbDelay that polls usb port (for system requests) while delaying. This is called instead of delay in the button and pin delay functions. Experimental evaluation gave that the cycle count should be roughly divided by 28.5.

This patch fixes the problem where TREZOR gets unresponsive after python-trezor was used and there was a long delay between button presses.