### PR TITLE
fixed salt passing to pbkdf2_hmac_sha512

### DIFF
--- a/firmware/storage.c
+++ b/firmware/storage.c
@@ -267,8 +267,10 @@ bool storage_getRootNode(HDNode *node)
 		if (storage.has_passphrase_protection && storage.passphrase_protection && strlen(sessionPassphrase)) {
 			// decrypt hd node
 			uint8_t secret[64];
+			uint8_t salt[12];
+			memcpy(salt, "TREZORHD", 8);
 			layoutProgressSwipe("Waking up", 0);
-			pbkdf2_hmac_sha512((const uint8_t *)sessionPassphrase, strlen(sessionPassphrase), (uint8_t *)"TREZORHD", 8, BIP39_PBKDF2_ROUNDS, secret, 64, get_root_node_callback);
+			pbkdf2_hmac_sha512((const uint8_t *)sessionPassphrase, strlen(sessionPassphrase), salt, 8, BIP39_PBKDF2_ROUNDS, secret, 64, get_root_node_callback);
 			aes_decrypt_ctx ctx;
 			aes_decrypt_key256(secret, &ctx);
 			aes_cbc_decrypt(sessionRootNode.chain_code, sessionRootNode.chain_code, 32, secret + 32, &ctx);


### PR DESCRIPTION
Call to pbkdf2_hmac_sha512() uses salt string pointer argument (“TREZORHD”), which is located in ROM memory.  But pbkdf2_hmac_sha512() is expecting the pointer from RAM as it modifies the content. Actual salt value being used ends up being 
“TREZORHD\0Sta” as the attempt to modify it fails, (also producing a flash error flag to be set).