### PR TITLE
firmware-docker-build: revert branch and repository selection

### DIFF
--- a/firmware-docker-build.sh
+++ b/firmware-docker-build.sh
@@ -1,10 +1,10 @@
 #!/bin/bash
 IMAGETAG=trezor-mcu-build
-FIRMWARETAG="ssh-agent"
+FIRMWARETAG=${1:-master}
 
 docker build -t $IMAGETAG .
 docker run -t -v $(pwd)/output:/output $IMAGETAG /bin/sh -c "\
-	git clone https://github.com/romanz/trezor-mcu && \
+	git clone https://github.com/trezor/trezor-mcu && \
 	cd trezor-mcu && \
 	git checkout $FIRMWARETAG && \
 	git submodule update --init && \


### PR DESCRIPTION
reverting to the original version of `firmware-docker-build.sh`.