### PR TITLE
firmware: exclude debug functionality from release build

### DIFF
--- a/firmware/pinmatrix.c
+++ b/firmware/pinmatrix.c
@@ -73,7 +73,11 @@ void pinmatrix_done(char *pin)
 	memset(pinmatrix_perm, 'X', sizeof(pinmatrix_perm));
 }
 
+#if DEBUG_LINK
+
 const char *pinmatrix_get(void)
 {
 	return pinmatrix_perm;
 }
+
+#endif

--- a/firmware/recovery.c
+++ b/firmware/recovery.c
@@ -169,6 +169,8 @@ void recovery_abort(void)
 	}
 }
 
+#if DEBUG_LINK
+
 const char *recovery_get_fake_word(void)
 {
 	return fake_word;
@@ -178,3 +180,5 @@ uint32_t recovery_get_word_pos(void)
 {
 	return word_pos;
 }
+
+#endif

--- a/firmware/reset.c
+++ b/firmware/reset.c
@@ -149,6 +149,8 @@ void reset_entropy(const uint8_t *ext_entropy, uint32_t len)
 	layoutHome();
 }
 
+#if DEBUG_LINK
+
 uint32_t reset_get_int_entropy(uint8_t *entropy) {
 	memcpy(entropy, int_entropy, 32);
 	return 32;
@@ -157,3 +159,5 @@ uint32_t reset_get_int_entropy(uint8_t *entropy) {
 const char *reset_get_word(void) {
 	return current_word;
 }
+
+#endif


### PR DESCRIPTION
These functions are called only by `fsm_msgDebugLinkGetState()`, which is excluded from release build.