### PR TITLE
bootloader: use regular object files

### DIFF
--- a/Makefile.include
+++ b/Makefile.include
@@ -114,9 +114,6 @@ $(NAME).elf: $(OBJS) $(LDSCRIPT) $(TOOLCHAIN_DIR)/lib/libopencm3_stm32f2.a $(TOP
 %.o: %.c Makefile
 	$(CC) $(CFLAGS) -o $@ -c $<
 
-%.small.o: %.c Makefile
-	$(CC) $(CFLAGS) -o $@ -c $<
-
 clean:
 	rm -f $(OBJS)
 	rm -f *.a

--- a/bootloader/Makefile
+++ b/bootloader/Makefile
@@ -5,10 +5,10 @@ OBJS += signatures.o
 OBJS += usb.o
 
 OBJS += ../trezor-crypto/bignum.o
-OBJS += ../trezor-crypto/ecdsa.small.o
+OBJS += ../trezor-crypto/ecdsa.o
 OBJS += ../trezor-crypto/hmac.o
 OBJS += ../trezor-crypto/ripemd160.o
-OBJS += ../trezor-crypto/secp256k1.small.o
+OBJS += ../trezor-crypto/secp256k1.o
 OBJS += ../trezor-crypto/sha2.o
 
 CFLAGS += -DUSE_PRECOMPUTED_IV=0


### PR DESCRIPTION
`*.small.o` is the same as `*.o`