### PR TITLE
Don't reflash storage after each PIN entry

### DIFF
--- a/firmware/storage.h
+++ b/firmware/storage.h
@@ -56,9 +56,9 @@ bool storage_hasPin(void);
 void storage_setPin(const char *pin);
 void session_cachePin(void);
 bool session_isPinCached(void);
-void storage_resetPinFails(void);
-void storage_increasePinFails(void);
-uint32_t storage_getPinFails(void);
+void storage_resetPinFails(uint32_t *pinfailptr);
+bool storage_increasePinFails(uint32_t *pinfailptr);
+uint32_t *storage_getPinFailsPtr(void);
 
 bool storage_isInitialized(void);
 


### PR DESCRIPTION
Instead of reflashing the whole storage, we use a designated area
in the second storage block, where we mark each PIN failure by a
single zero bit. This is because one can set bits in flash to zero but
not to one.  If the PIN was entered successfully the whole word is
set to zero and the next word stores the new PIN failure counter.