### PR TITLE
crypto: add ECDH session key generation

### DIFF
--- a/firmware/crypto.h
+++ b/firmware/crypto.h
@@ -37,6 +37,9 @@ int sshMessageSign(const HDNode *node, const uint8_t *message, size_t message_le
 
 int gpgMessageSign(const HDNode *node, const uint8_t *message, size_t message_len, uint8_t *signature);
 
+int cryptoGetECDHSessionKey(const HDNode *node, const uint8_t *peer_public_key, uint8_t *session_key);
+
+
 int cryptoMessageSign(const CoinType *coin, const HDNode *node, const uint8_t *message, size_t message_len, uint8_t *signature);
 
 int cryptoMessageVerify(const CoinType *coin, const uint8_t *message, size_t message_len, const uint8_t *address_raw, const uint8_t *signature);


### PR DESCRIPTION
This will allow to implement ECDH support for GPG 2.1+, after https://github.com/trezor/trezor-common/pull/12 is merged.
See https://github.com/trezor/trezor-mcu/issues/85 for more details.