### PR TITLE
Add ECDH support to TREZOR API

### DIFF
--- a/firmware/fsm.h
+++ b/firmware/fsm.h
@@ -51,6 +51,7 @@ void fsm_msgEntropyAck(EntropyAck *msg);
 void fsm_msgSignMessage(SignMessage *msg);
 void fsm_msgVerifyMessage(VerifyMessage *msg);
 void fsm_msgSignIdentity(SignIdentity *msg);
+void fsm_msgGetECDHSessionKey(GetECDHSessionKey *msg);
 void fsm_msgEncryptMessage(EncryptMessage *msg);
 void fsm_msgDecryptMessage(DecryptMessage *msg);
 //void fsm_msgPassphraseAck(PassphraseAck *msg);

--- a/firmware/messages.c
+++ b/firmware/messages.c
@@ -63,6 +63,7 @@ static const struct MessagesMap_t MessagesMap[] = {
 	{'n', 'i', MessageType_MessageType_SignMessage,			SignMessage_fields,			(void (*)(void *))fsm_msgSignMessage},
 	{'n', 'i', MessageType_MessageType_SignIdentity,		SignIdentity_fields,		(void (*)(void *))fsm_msgSignIdentity},
 	{'n', 'i', MessageType_MessageType_VerifyMessage,		VerifyMessage_fields,		(void (*)(void *))fsm_msgVerifyMessage},
+	{'n', 'i', MessageType_MessageType_GetECDHSessionKey,		GetECDHSessionKey_fields,	(void (*)(void *))fsm_msgGetECDHSessionKey},
 /* ECIES disabled
 	{'n', 'i', MessageType_MessageType_EncryptMessage,		EncryptMessage_fields,		(void (*)(void *))fsm_msgEncryptMessage},
 	{'n', 'i', MessageType_MessageType_DecryptMessage,		DecryptMessage_fields,		(void (*)(void *))fsm_msgDecryptMessage},
@@ -86,6 +87,7 @@ static const struct MessagesMap_t MessagesMap[] = {
 	{'n', 'o', MessageType_MessageType_EntropyRequest,		EntropyRequest_fields,		0},
 	{'n', 'o', MessageType_MessageType_MessageSignature,	MessageSignature_fields,	0},
 	{'n', 'o', MessageType_MessageType_SignedIdentity,		SignedIdentity_fields,		0},
+	{'n', 'o', MessageType_MessageType_ECDHSessionKey,		ECDHSessionKey_fields,		0},
 /* ECIES disabled
 	{'n', 'o', MessageType_MessageType_EncryptedMessage,	EncryptedMessage_fields,	0},
 	{'n', 'o', MessageType_MessageType_DecryptedMessage,	DecryptedMessage_fields,	0},


### PR DESCRIPTION
I was not sure about the correct way to confirm the ECDH session key generation (see the comment at line 787), so currently it uses PIN-based protection only, similar to the `GetPublicKey` API.