### PR TITLE
add python-ecdsa dependency

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,4 +8,4 @@ RUN apt-get update
 
 # install build tools and dependencies
 
-RUN apt-get install -y build-essential git python gcc-arm-none-eabi
+RUN apt-get install -y build-essential git python python-ecdsa gcc-arm-none-eabi


### PR DESCRIPTION
I wanted to use `make sign` inside the container and found this dependency to be missing.