### PR TITLE
Update coins.c for Zcash mainnet

### DIFF
--- a/firmware/coins.c
+++ b/firmware/coins.c
@@ -28,6 +28,7 @@ const CoinType coins[COINS_COUNT] = {
 	{true, "Litecoin", true, "LTC",  true,  48, true,    1000000, true,   5, false, 0, false, 0, true, "\x19" "Litecoin Signed Message:\n"},
 	{true, "Dogecoin", true, "DOGE", true,  30, true, 1000000000, true,  22, false, 0, false, 0, true, "\x19" "Dogecoin Signed Message:\n"},
 	{true, "Dash",     true, "DASH", true,  76, true,     100000, true,  16, false, 0, false, 0, true, "\x19" "DarkCoin Signed Message:\n"},
+	{true, "Zcash",    true, "ZEC",  true,  65, true,    1000000, true,   5, false, 0, false, 0, true, "\x19" "Zcash Signed Message:\n"},
 };
 
 const CoinType *coinByShortcut(const char *shortcut)


### PR DESCRIPTION
Address prefix is 'T' (uppercase) so address byte is 65 (decimal).

It was not clear from the CoinType protobuf definition what the byte 0x18 or 0x19 before the signed message represented.  Since only Bitcoin uses 0x18 and all others use 0x19, this patch uses 0x19.  Please change where appropriate.