### PR TITLE
Reworked rfc6979 signing.

### DIFF
--- a/firmware/crypto.c
+++ b/firmware/crypto.c
@@ -88,7 +88,7 @@ uint32_t deser_length(const uint8_t *in, uint32_t *out)
 int sshMessageSign(HDNode *node, const uint8_t *message, size_t message_len, uint8_t *signature)
 {
 	signature[0] = 0; // prefix: pad with zero, so all signatures are 65 bytes
-	return hdnode_sign(node, message, message_len, signature + 1, NULL);
+	return hdnode_sign(node, message, message_len, signature + 1, NULL, NULL);
 }
 
 int gpgMessageSign(HDNode *node, const uint8_t *message, size_t message_len, uint8_t *signature)
@@ -98,7 +98,7 @@ int gpgMessageSign(HDNode *node, const uint8_t *message, size_t message_len, uin
 		return 1;
 	}
 	signature[0] = 0; // prefix: pad with zero, so all signatures are 65 bytes
-	return hdnode_sign_digest(node, message, signature + 1, NULL);
+	return hdnode_sign_digest(node, message, signature + 1, NULL, NULL);
 }
 
 int cryptoGetECDHSessionKey(const HDNode *node, const uint8_t *peer_public_key, uint8_t *session_key)
@@ -133,7 +133,7 @@ int cryptoMessageSign(const CoinType *coin, HDNode *node, const uint8_t *message
 	sha256_Final(&ctx, hash);
 	sha256_Raw(hash, 32, hash);
 	uint8_t pby;
-	int result = hdnode_sign_digest(node, hash, signature + 1, &pby);
+	int result = hdnode_sign_digest(node, hash, signature + 1, &pby, NULL);
 	if (result == 0) {
 		signature[0] = 27 + pby + 4;
 	}

--- a/firmware/signing.c
+++ b/firmware/signing.c
@@ -540,7 +540,7 @@ void signing_txack(TransactionType *tx)
 				resp.serialized.signature_index = idx1;
 				resp.serialized.has_signature = true;
 				resp.serialized.has_serialized_tx = true;
-				ecdsa_sign_digest(&secp256k1, privkey, hash, sig, 0);
+				ecdsa_sign_digest(&secp256k1, privkey, hash, sig, NULL, NULL);
 				resp.serialized.signature.size = ecdsa_sig_to_der(sig, resp.serialized.signature.bytes);
 				if (input.script_type == InputScriptType_SPENDMULTISIG) {
 					if (!input.has_multisig) {

--- a/firmware/u2f.c
+++ b/firmware/u2f.c
@@ -617,7 +617,7 @@ void u2f_register(const APDU *a)
 		memcpy(sig_base.keyHandle, &resp->keyHandleCertSig, KEY_HANDLE_LEN);
 		memcpy(sig_base.pubKey, &resp->pubKey, U2F_PUBKEY_LEN);
 		ecdsa_sign(&nist256p1, U2F_ATT_PRIV_KEY, (uint8_t *)&sig_base,
-			   sizeof(sig_base), sig, NULL);
+			   sizeof(sig_base), sig, NULL, NULL);
 
 		// Where to write the signature in the response
 		uint8_t *resp_sig = resp->keyHandleCertSig +
@@ -738,7 +738,7 @@ void u2f_authenticate(const APDU *a)
 		memcpy(sig_base.chal, req->chal, U2F_CHAL_SIZE);
 		ecdsa_sign(&nist256p1, node->private_key,
 			   (uint8_t *)&sig_base, sizeof(sig_base), sig,
-			   NULL);
+			   NULL, NULL);
 
 		// Copy DER encoded signature into response
 		const uint8_t sig_len = ecdsa_sig_to_der(sig, resp->sig);


### PR DESCRIPTION
This is the second part of the rfc6979 signing patch.  It must be applied together with the corresponding patch in trezor-crypto.

New parameter is_canonical that allows for generating signatures that
have additional requirements.