### PR TITLE
Adding Curve25519 ECDH support for GPG decryption

### DIFF
--- a/Makefile.include
+++ b/Makefile.include
@@ -49,6 +49,7 @@ CFLAGS   += $(OPTFLAGS) \
             -I$(TOP_DIR)gen \
             -I$(TOP_DIR)vendor/trezor-crypto \
             -I$(TOP_DIR)vendor/trezor-crypto/ed25519-donna \
+            -I$(TOP_DIR)vendor/trezor-crypto/curve25519-donna \
             -I$(TOP_DIR)vendor/trezor-qrenc
 
 ifdef APPVER

--- a/firmware/Makefile
+++ b/firmware/Makefile
@@ -28,6 +28,7 @@ OBJS += ../vendor/trezor-crypto/curves.o
 OBJS += ../vendor/trezor-crypto/secp256k1.o
 OBJS += ../vendor/trezor-crypto/nist256p1.o
 OBJS += ../vendor/trezor-crypto/ed25519-donna/ed25519.o
+OBJS += ../vendor/trezor-crypto/curve25519-donna/curve25519-donna.o
 OBJS += ../vendor/trezor-crypto/hmac.o
 OBJS += ../vendor/trezor-crypto/bip32.o
 OBJS += ../vendor/trezor-crypto/bip39.o

--- a/firmware/crypto.c
+++ b/firmware/crypto.c
@@ -103,25 +103,6 @@ int gpgMessageSign(HDNode *node, const uint8_t *message, size_t message_len, uin
 	return hdnode_sign_digest(node, message, signature + 1, NULL, NULL);
 }
 
-int cryptoGetECDHSessionKey(const HDNode *node, const uint8_t *peer_public_key, uint8_t *session_key)
-{
-	curve_point point;
-	const ecdsa_curve *curve = node->curve->params;
-	if (!ecdsa_read_pubkey(curve, peer_public_key, &point)) {
-		return 1;
-	}
-	bignum256 k;
-	bn_read_be(node->private_key, &k);
-	point_multiply(curve, &k, &point, &point);
-	MEMSET_BZERO(&k, sizeof(k));
-
-	session_key[0] = 0x04;
-	bn_write_be(&point.x, session_key + 1);
-	bn_write_be(&point.y, session_key + 33);
-	MEMSET_BZERO(&point, sizeof(point));
-	return 0;
-}
-
 int cryptoMessageSign(const CoinType *coin, HDNode *node, const uint8_t *message, size_t message_len, uint8_t *signature)
 {
 	SHA256_CTX ctx;

--- a/firmware/crypto.h
+++ b/firmware/crypto.h
@@ -37,8 +37,6 @@ int sshMessageSign(HDNode *node, const uint8_t *message, size_t message_len, uin
 
 int gpgMessageSign(HDNode *node, const uint8_t *message, size_t message_len, uint8_t *signature);
 
-int cryptoGetECDHSessionKey(const HDNode *node, const uint8_t *peer_public_key, uint8_t *session_key);
-
 int cryptoMessageSign(const CoinType *coin, HDNode *node, const uint8_t *message, size_t message_len, uint8_t *signature);
 
 int cryptoMessageVerify(const CoinType *coin, const uint8_t *message, size_t message_len, uint32_t address_type, const uint8_t *address_raw, const uint8_t *signature);

--- a/firmware/fsm.c
+++ b/firmware/fsm.c
@@ -906,9 +906,10 @@ void fsm_msgGetECDHSessionKey(GetECDHSessionKey *msg)
 	const HDNode *node = fsm_getDerivedNode(curve, address_n, 5);
 	if (!node) return;
 
-	if (cryptoGetECDHSessionKey(node, msg->peer_public_key.bytes, resp->session_key.bytes) == 0) {
+	int result_size = 0;
+	if (hdnode_get_shared_key(node, msg->peer_public_key.bytes, resp->session_key.bytes, &result_size) == 0) {
 		resp->has_session_key = true;
-		resp->session_key.size = 65;
+		resp->session_key.size = result_size;
 		msg_write(MessageType_MessageType_ECDHSessionKey, resp);
 	} else {
 		fsm_sendFailure(FailureType_Failure_Other, "Error getting ECDH session key");


### PR DESCRIPTION
This PR depends on https://github.com/trezor/trezor-crypto/pull/74.

Usage example (using the latest version of https://github.com/romanz/trezor-agent/pull/51):
```
$ export TREZOR_GPG_USER_ID="testing1"
$ trezor-gpg create -e ed25519 | gpg2 --import
$ gpg2 -k
pub   ed25519 2016-10-15 [SC]
      404376483FF50B280DE488BF7A16540A8435DBE7
uid           [ultimate] testing1
sub   cv25519 2016-10-15 [E]
$ trezor-gpg agent &
$ echo "Hello World!" | gpg2 --sign | gpg2 --verify
gpg: Signature made Sat 15 Oct 2016 03:51:26 PM IDT
gpg:                using EDDSA key 7A16540A8435DBE7
gpg: Good signature from "testing1" [ultimate]
$ date | gpg2 --encrypt -r "${TREZOR_GPG_USER_ID}" | gpg2 --decrypt
gpg: encrypted with 256-bit ECDH key, ID CDA4FB36AC6FDFDD, created 2016-10-15
      "testing1"
Sat Oct 15 15:51:31 IDT 2016
```