### PR TITLE
Support for txs with no inputs

### DIFF
--- a/firmware/signing.c
+++ b/firmware/signing.c
@@ -276,7 +276,11 @@ void signing_init(uint32_t _inputs_count, uint32_t _outputs_count, const CoinTyp
 
 	layoutProgressSwipe("Signing transaction", 0);
 
-	send_req_1_input();
+	if (inputs_count > 0) {
+		send_req_1_input();
+	} else {
+		send_req_3_output();
+	}
 }
 
 #define MIN(a,b) (((a)<(b))?(a):(b))
@@ -334,7 +338,11 @@ void signing_txack(TransactionType *tx)
 			tx_init(&tp, tx->inputs_cnt, tx->outputs_cnt, tx->version, tx->lock_time, tx->extra_data_len, false);
 			progress_meta_step = progress_step / (tp.inputs_len + tp.outputs_len);
 			idx2 = 0;
-			send_req_2_prev_input();
+			if (tp.inputs_len > 0) {
+				send_req_2_prev_input();
+			} else {
+				send_req_2_prev_output();
+			}
 			return;
 		case STAGE_REQUEST_2_PREV_INPUT:
 			progress = (idx1 * progress_step + idx2 * progress_meta_step) >> PROGRESS_PRECISION;
@@ -493,7 +501,11 @@ void signing_txack(TransactionType *tx)
 				layoutProgress("Signing transaction", progress);
 				idx1 = 0;
 				idx2 = 0;
-				send_req_4_input();
+				if (inputs_count > 0) {
+					send_req_4_input();
+				} else {
+					send_req_4_output();
+				}
 			}
 			return;
 		}


### PR DESCRIPTION
Some transactions in zcash can have no inputs (all "inputs" are joinsplits, that are in extra data here).

I have tried to add support for transactions without inputs.

*However* - I might have added too many `if`s - because only the *previous* transactions can have 0 inputs, not the transaction I am currently signing (as of right now).

Also I haven't tested this at all :) will do tomorrow