### PR TITLE
Use Cortex-M3 SysTick timers

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,6 +6,7 @@ OBJS += serialno.o
 OBJS += setup.o
 OBJS += util.o
 OBJS += memory.o
+OBJS += timer.o
 OBJS += gen/bitmaps.o
 OBJS += gen/fonts.o
 

--- a/firmware/layout2.c
+++ b/firmware/layout2.c
@@ -28,6 +28,7 @@
 #include "string.h"
 #include "util.h"
 #include "qr_encode.h"
+#include "timer.h"
 
 void *layoutLast = layoutHome;
 
@@ -81,6 +82,9 @@ void layoutHome(void)
 		}
 	}
 	oledRefresh();
+
+	// Reset lock screen timeout
+	system_millis_lock = system_millis + SCREEN_TIMEOUT_MILLIS;
 }
 
 const char *str_amount(uint64_t amnt, const char *abbr, char *buf, int len)

--- a/firmware/protect.c
+++ b/firmware/protect.c
@@ -58,7 +58,7 @@ bool protectButton(ButtonRequestType type, bool confirm_only)
 
 		// button acked - check buttons
 		if (acked) {
-			usbDelay(3300);
+			usbSleep(5);
 			buttonUpdate();
 			if (button.YesUp) {
 				result = true;
@@ -165,7 +165,7 @@ bool protectPin(bool use_cached)
 		}
 		layoutDialog(&bmp_icon_info, NULL, NULL, NULL, "Wrong PIN entered", NULL, "Please wait", secstr, "to continue ...", NULL);
 		// wait one second
-		usbDelay(800000);
+		usbSleep(1000);
 		if (msg_tiny_id == MessageType_MessageType_Initialize) {
 			protectAbortedByInitialize = true;
 			msg_tiny_id = 0xFFFF;

--- a/firmware/storage.c
+++ b/firmware/storage.c
@@ -338,7 +338,7 @@ void storage_setHomescreen(const uint8_t *data, uint32_t size)
 
 void get_root_node_callback(uint32_t iter, uint32_t total)
 {
-	usbDelay(10); // handle up to ten usb interrupts.
+	usbSleep(1);
 	layoutProgress("Waking up", 1000 * iter / total);
 }
 

--- a/firmware/trezor.c
+++ b/firmware/trezor.c
@@ -38,15 +38,12 @@ void __attribute__((noreturn)) __stack_chk_fail(void)
 	for (;;) {} // loop forever
 }
 
-static uint32_t saver_counter = 0;
-
 void check_lock_screen(void)
 {
 	buttonUpdate();
 
 	// wake from screensaver on any button
 	if (layoutLast == layoutScreensaver && (button.NoUp || button.YesUp)) {
-		saver_counter = 0;
 		layoutHome();
 		return;
 	}
@@ -82,15 +79,11 @@ void check_lock_screen(void)
 
 	// if homescreen is shown for longer than 10 minutes, lock too
 	if (layoutLast == layoutHome) {
-		saver_counter++;
-		if (saver_counter > 285000 * 60 * 10) {
+		if (system_millis >= system_millis_lock) {
 			// lock the screen
 			session_clear(true);
 			layoutScreensaver();
-			saver_counter = 0;
 		}
-	} else {
-		saver_counter = 0;
 	}
 }
 

--- a/firmware/trezor.c
+++ b/firmware/trezor.c
@@ -27,6 +27,7 @@
 #include "layout.h"
 #include "layout2.h"
 #include "rng.h"
+#include "timer.h"
 #include "buttons.h"
 
 uint32_t __stack_chk_guard;
@@ -58,13 +59,13 @@ void check_lock_screen(void)
 		// wait until NoButton is released
 		usbTiny(1);
 		do {
-			usbDelay(3300);
+			usbSleep(5);
 			buttonUpdate();
 		} while (!button.NoUp);
 
 		// wait for confirmation/cancellation of the dialog
 		do {
-			usbDelay(3300);
+			usbSleep(5);
 			buttonUpdate();
 		} while (!button.YesUp && !button.NoUp);
 		usbTiny(0);
@@ -102,6 +103,9 @@ int main(void)
 #else
 	setupApp();
 #endif
+
+	timer_init();
+
 #if DEBUG_LINK
 	oledSetDebug(1);
 	storage_reset(); // wipe storage if debug link

--- a/firmware/usb.c
+++ b/firmware/usb.c
@@ -27,6 +27,7 @@
 #include "u2f.h"
 #include "storage.h"
 #include "util.h"
+#include "timer.h"
 
 #define USB_INTERFACE_INDEX_MAIN 0
 #if DEBUG_LINK
@@ -426,9 +427,10 @@ char usbTiny(char set)
 	return old;
 }
 
-void usbDelay(int cycles)
+void usbSleep(uint32_t millis)
 {
-	while (cycles--) {
+	uint32_t end = system_millis + millis;
+	while (end > system_millis) {
 		usbd_poll(usbd_dev);
 	}
 }

--- a/timer.c
+++ b/timer.c
@@ -26,6 +26,9 @@
 /* 1 tick = 1 ms */
 volatile uint32_t system_millis;
 
+/* Screen timeout */
+uint32_t system_millis_lock;
+
 /*
  * Initialise the Cortex-M3 SysTick timer
  */

--- a/timer.c
+++ b/timer.c
@@ -1,0 +1,61 @@
+/*
+ * This file is part of the TREZOR project.
+ *
+ * Copyright (C) 2016 Saleem Rashid <trezor@saleemrashid.com>
+ *
+ * This library is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this library.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+
+#include "timer.h"
+
+#include <libopencm3/stm32/rcc.h>
+#include <libopencm3/cm3/systick.h>
+
+/* 1 tick = 1 ms */
+volatile uint32_t system_millis;
+
+/*
+ * Initialise the Cortex-M3 SysTick timer
+ */
+void timer_init(void) {
+	system_millis = 0;
+
+	/*
+	 * MCU clock (120 MHz) as source
+	 *
+	 *     (120 MHz / 8) = 15 clock pulses
+	 *
+	 */
+	systick_set_clocksource(STK_CSR_CLKSOURCE_AHB_DIV8);
+	STK_CVR = 0;
+
+	/*
+	 * 1 tick = 1 ms @ 120 MHz
+	 *
+	 *     (15 clock pulses * 1000 ms) = 15000 clock pulses
+	 *
+	 * Send an interrupt every (N - 1) clock pulses
+	 */
+	systick_set_reload(14999);
+
+	/* SysTick as interrupt */
+	systick_interrupt_enable();
+
+	systick_counter_enable();
+}
+
+void sys_tick_handler(void) {
+	system_millis++;
+}

--- a/timer.h
+++ b/timer.h
@@ -23,6 +23,11 @@
 /* 1 tick = 1 ms */
 extern volatile uint32_t system_millis;
 
+/* Screen timeout */
+extern uint32_t system_millis_lock;
+
+#define SCREEN_TIMEOUT_MILLIS (1000 * 60 * 10) /* 10 minutes */
+
 void timer_init(void);
 
 void sys_tick_handler(void);

--- a/timer.h
+++ b/timer.h
@@ -1,7 +1,7 @@
 /*
  * This file is part of the TREZOR project.
  *
- * Copyright (C) 2014 Pavol Rusnak <stick@satoshilabs.com>
+ * Copyright (C) 2016 Saleem Rashid <trezor@saleemrashid.com>
  *
  * This library is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published by
@@ -17,13 +17,12 @@
  * along with this library.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-#ifndef __USB_H__
-#define __USB_H__
 
-void usbInit(void);
-void usbPoll(void);
-void usbReconnect(void);
-char usbTiny(char set);
-void usbSleep(uint32_t millis);
+#include <stdint.h>
 
-#endif
+/* 1 tick = 1 ms */
+extern volatile uint32_t system_millis;
+
+void timer_init(void);
+
+void sys_tick_handler(void);


### PR DESCRIPTION
SysTick timers provide efficient and incredibly accurate timings. This pull request removes `usbDelay(uint32_t cycles)` in favour of `usbSleep(uint32_t millis)` which is implemented with the aforementioned SysTick timers.