### PR TITLE
timer: Fix non-critical integer overflow

### DIFF
--- a/firmware/layout2.c
+++ b/firmware/layout2.c
@@ -84,7 +84,7 @@ void layoutHome(void)
 	oledRefresh();
 
 	// Reset lock screen timeout
-	system_millis_lock = system_millis + SCREEN_TIMEOUT_MILLIS;
+	system_millis_lock_start = system_millis;
 }
 
 const char *str_amount(uint64_t amnt, const char *abbr, char *buf, int len)

--- a/firmware/trezor.c
+++ b/firmware/trezor.c
@@ -79,7 +79,7 @@ void check_lock_screen(void)
 
 	// if homescreen is shown for longer than 10 minutes, lock too
 	if (layoutLast == layoutHome) {
-		if (system_millis >= system_millis_lock) {
+		if ((system_millis - system_millis_lock_start) >= 60000) {
 			// lock the screen
 			session_clear(true);
 			layoutScreensaver();

--- a/firmware/usb.c
+++ b/firmware/usb.c
@@ -429,8 +429,9 @@ char usbTiny(char set)
 
 void usbSleep(uint32_t millis)
 {
-	uint32_t end = system_millis + millis;
-	while (end > system_millis) {
+	uint32_t start = system_millis;
+
+	while ((system_millis - start) < millis) {
 		usbd_poll(usbd_dev);
 	}
 }

--- a/timer.c
+++ b/timer.c
@@ -27,7 +27,7 @@
 volatile uint32_t system_millis;
 
 /* Screen timeout */
-uint32_t system_millis_lock;
+uint32_t system_millis_lock_start;
 
 /*
  * Initialise the Cortex-M3 SysTick timer

--- a/timer.h
+++ b/timer.h
@@ -24,9 +24,7 @@
 extern volatile uint32_t system_millis;
 
 /* Screen timeout */
-extern uint32_t system_millis_lock;
-
-#define SCREEN_TIMEOUT_MILLIS (1000 * 60 * 10) /* 10 minutes */
+extern uint32_t system_millis_lock_start;
 
 void timer_init(void);
 


### PR DESCRIPTION
Every 4294967295 milliseconds (2 ^ 32 - 1), `system_millis` will overflow.
This means that every 49.71 days, `system_millis` will reset to zero.
Comparisons like `system_millis < (system_millis + 1)` would fail if the
latter had overflown and the former had not.

This is non-critical because the worst case is that one second could be
skipped or the screen could lock early.

This poses no threat to the exponential backoff used for protection
against brute force.

Thanks to @jhoenicke for the provided solution :heart: