### PR TITLE
Improve debugging API

### DIFF
--- a/firmware/debug.c
+++ b/firmware/debug.c
@@ -20,6 +20,7 @@
 #include "trezor.h"
 #include "debug.h"
 #include "oled.h"
+#include "util.h"
 
 #if DEBUG_LOG
 
@@ -48,6 +49,17 @@ void debugLog(int level, const char *bucket, const char *text)
 	(void)level;
 	(void)bucket;
 	oledDebug(text);
+}
+
+char *debugInt(const uint32_t i)
+{
+	static uint8_t n = 0;
+	static char id[8][9];
+	uint32hex(i, id[n]);
+	debugLog(0, "", id[n]);
+	char *ret = (char *)id[n];
+	n = (n + 1) % 8;
+	return ret;
 }
 
 #endif

--- a/firmware/debug.h
+++ b/firmware/debug.h
@@ -21,14 +21,17 @@
 #define __DEBUG_H__
 
 #include "trezor.h"
+#include <stdint.h>
 
 #if DEBUG_LOG
 
 void debugLog(int level, const char *bucket, const char *text);
+char *debugInt(const uint32_t i);
 
 #else
 
 #define debugLog(L, B, T) do{}while(0)
+#define debugInt(I) do{}while(0)
 
 #endif
 

--- a/firmware/trezor.c
+++ b/firmware/trezor.c
@@ -99,8 +99,11 @@ int main(void)
 
 	timer_init();
 
-#if DEBUG_LINK
+#if DEBUG_LOG
 	oledSetDebug(1);
+#endif
+
+#if DEBUG_LINK
 	storage_reset(); // wipe storage if debug link
 	storage_reset_uuid();
 	storage_commit();

--- a/firmware/u2f.c
+++ b/firmware/u2f.c
@@ -92,22 +92,6 @@ typedef struct {
 	uint8_t chal[U2F_CHAL_SIZE];
 } U2F_AUTHENTICATE_SIG_STR;
 
-
-#if DEBUG_LOG
-char *debugInt(const uint32_t i)
-{
-	static uint8_t n = 0;
-	static char id[8][9];
-	uint32hex(i, id[n]);
-	debugLog(0, "", id[n]);
-	char *ret = (char *)id[n];
-	n = (n + 1) % 8;
-	return ret;
-}
-#else
-#define debugInt(I) do{}while(0)
-#endif
-
 static uint32_t dialog_timeout = 0;
 
 uint32_t next_cid(void)


### PR DESCRIPTION
`DEBUG_LINK` has a lot of side effects but was necessary for `DEBUG_LOG`

* Allow `DEBUG_LOG` without `DEBUG_LINK`
* Move `debugInt()` to `debug.c`