### PR TITLE
memory protection: do not write reserved bits

### DIFF
--- a/memory.c
+++ b/memory.c
@@ -27,13 +27,23 @@
 
 void memory_protect(void)
 {
+	// Reference STM32F205 Flash programming manual revision 5 http://www.st.com/resource/en/programming_manual/cd00233952.pdf
+	// Section 2.6 Option bytes
 	//                     set RDP level 2                   WRP for sectors 0 and 1
-	if ((((*OPTION_BYTES_1) & 0xFFFF) == 0xCCFF) && (((*OPTION_BYTES_2) & 0xFFFF) == 0xFFFC)) {
+	if ((((*OPTION_BYTES_1) & 0xFFEC) == 0xCCEC) && (((*OPTION_BYTES_2) & 0xFFF) == 0xFFC)) {
 		return; // already set up correctly - bail out
 	}
 	flash_unlock_option_bytes();
-	//                                WRP +    RDP
-	flash_program_option_bytes(0xFFFC0000 + 0xCCFF);
+	// Section 2.8.6 Flash option control register (FLASH_OPTCR)
+	//   Bits 31:28 Reserved, must be kept cleared.
+	//   Bits 27:16 nWRP: Not write protect: write protect bootloader code in flash main memory sectors 0 and 1 (Section 2.3; table 2)
+	//   Bits 15:8 RDP: Read protect: level 2 chip read protection active
+	//   Bits 7:5 USER: User option bytes: no reset on standby, no reset on stop, software watchdog
+	//   Bit 4 Reserved, must be kept cleared.
+	//   Bits 3:2 BOR_LEV: BOR reset Level: BOR off
+	//   Bit 1 OPTSTRT: Option start: ignored by flash_program_option_bytes
+	//   Bit 0 OPTLOCK: Option lock: ignored by flash_program_option_bytes
+	flash_program_option_bytes(0x0FFCCCEC);
 	flash_lock_option_bytes();
 }
 


### PR DESCRIPTION
Hi, based on the [hardware BOM](https://doc.satoshilabs.com/trezor-tech/hardware.html) that lists STM32F205RE as the MCU being used, I reviewed the bootloader protection code this morning.

I'm proposing some updates to not set reserved bits (which may lead to undefined behavior?) and to remove an unnecessary call to `flash_unlock_option_bytes` see also: https://github.com/libopencm3/libopencm3/blob/master/lib/stm32/common/flash_common_f24.c#L402-L413

I also added references to the manual that explains more about what is going on. I have not tested this code, so, please review.