### PR TITLE
fix issue #150

### DIFF
--- a/bootloader/bootloader.c
+++ b/bootloader/bootloader.c
@@ -139,8 +139,8 @@ void __attribute__((noreturn)) __stack_chk_fail(void)
 
 int main(void)
 {
-	__stack_chk_guard = random32();
 	setup();
+	__stack_chk_guard = random32(); // this supports compiler provided unpredictable stack protection checks
 	memory_protect();
 	oledInit();
 

--- a/demo/demo.c
+++ b/demo/demo.c
@@ -248,11 +248,15 @@ void __attribute__((noreturn)) __stack_chk_fail(void)
 
 int main(void)
 {
-	__stack_chk_guard = random32();
 #ifndef APPVER
 	setup();
+	__stack_chk_guard = random32(); // this supports compiler provided unpredictable stack protection checks
 	oledInit();
+#else
+	setupApp();
+	__stack_chk_guard = random32(); // this supports compiler provided unpredictable stack protection checks
 #endif
+
 	usbInit();
 
 	passlen = strlen((char *)pass);

--- a/firmware/trezor.c
+++ b/firmware/trezor.c
@@ -89,12 +89,13 @@ void check_lock_screen(void)
 
 int main(void)
 {
-	__stack_chk_guard = random32();
 #ifndef APPVER
 	setup();
+	__stack_chk_guard = random32(); // this supports compiler provided unpredictable stack protection checks
 	oledInit();
 #else
 	setupApp();
+	__stack_chk_guard = random32(); // this supports compiler provided unpredictable stack protection checks
 #endif
 
 	timer_init();


### PR DESCRIPTION
Here's a patch to address #150. It needs review and testing, especially since it changes the bootloader and I'm coding while sleepy.

The only thing that may be surprising is that I removed the call to setup and oledInit at the beginning of the firmware. My reason for doing so is that the bootloader already handles those things.

My basic firmware tests of this patch passed, but I'll do some more testing tomorrow.