### PR TITLE
possible rng error hang and recovery

### DIFF
--- a/firmware/Makefile
+++ b/firmware/Makefile
@@ -59,6 +59,7 @@ CFLAGS += -Wno-sequence-point
 CFLAGS += -Iprotob -DPB_FIELD_16BIT=1
 CFLAGS += -DQR_MAX_VERSION=0
 CFLAGS += -DDEBUG_LINK=0
+CFLAGS += -DDEBUG_RNG=0
 CFLAGS += -DDEBUG_LOG=0
 CFLAGS += -DSCM_REVISION='"$(shell git rev-parse HEAD | sed 's:\(..\):\\x\1:g')"'
 CFLAGS += -DED25519_CUSTOMRANDOM=1

--- a/firmware/fsm.c
+++ b/firmware/fsm.c
@@ -292,12 +292,14 @@ void fsm_msgFirmwareUpload(FirmwareUpload *msg)
 
 void fsm_msgGetEntropy(GetEntropy *msg)
 {
+#if !DEBUG_RNG
 	layoutDialogSwipe(&bmp_icon_question, "Cancel", "Confirm", NULL, "Do you really want to", "send entropy?", NULL, NULL, NULL, NULL);
 	if (!protectButton(ButtonRequestType_ButtonRequest_ProtectCall, false)) {
 		fsm_sendFailure(FailureType_Failure_ActionCancelled, "Entropy cancelled");
 		layoutHome();
 		return;
 	}
+#endif
 	RESP_INIT(Entropy);
 	uint32_t len = msg->size;
 	if (len > 1024) {

--- a/firmware/trezor.h
+++ b/firmware/trezor.h
@@ -31,6 +31,10 @@
 #define DEBUG_LINK 0
 #endif
 
+#ifndef DEBUG_RNG
+#define DEBUG_RNG 0
+#endif
+
 #ifndef DEBUG_LOG
 #define DEBUG_LOG 0
 #endif

--- a/rng.c
+++ b/rng.c
@@ -27,7 +27,7 @@ uint32_t random32(void)
 {
 	static uint32_t last = 0, new = 0;
 	while (new == last) {
-		if (((RNG_SR & (RNG_SR_SEIS | RNG_SR_CEIS)) == 0) && ((RNG_SR & RNG_SR_DRDY) > 0)) {
+		if ((RNG_SR & (RNG_SR_SECS | RNG_SR_CECS | RNG_SR_DRDY)) == RNG_SR_DRDY) {
 			new = RNG_DR;
 		}
 	}

--- a/setup.c
+++ b/setup.c
@@ -42,7 +42,7 @@ void setup(void)
 
 	// enable RNG
 	rcc_periph_clock_enable(RCC_RNG);
-	RNG_CR |= RNG_CR_IE | RNG_CR_RNGEN;
+	RNG_CR |= RNG_CR_RNGEN;
 	// to be extra careful and heed the STM32F205xx Reference manual, Section 20.3.1
 	// we don't use the first random number generated after setting the RNGEN bit in setup
 	random32();


### PR DESCRIPTION
first, this change does not set the interrupt enable bit in the rng control register. currently, the interrupt is not handled, it's not even enabled in the nvic.

second, this change checks the SECS and CECS bits in the rng status register directly, rather than indirectly via SEIS and CEIS.
the way i read the manual, SECS and SEIS, and CECS and CEIS, match when an error is first detected.
but, SEIS and CEIS do not stay synched with the clock and fault detector as SECS and CECS do.
so, when an error occurs SEIS and CEIS go high and stay high because our code never resets them.
it's possible that an error passes and SECS and CECS then go low again. that's why it's better to check them instead.
as it is, if an rng error occured, things would appear to just hang.

the other way to look at it is that once an rng error is detected, it's better to just unplug the device and totally start over.
we don't do any of the recommened error recovery -- even this PR just waits until the rng hardware hopefully self-corrects.
but, i think this PR gets closer to the sweet spot in the ability to recover without user interaction given the kinds of possible error conditions that i see being possible.

from the STM32F205xx reference manual section 20.4.2:

  Bit 6 SEIS: Seed error interrupt status:
    This bit is set at the same time as SECS, it is cleared by writing it to 0.

  Bit 5 CEIS: Clock error interrupt status:
    This bit is set at the same time as CECS, it is cleared by writing it to 0.

  Bit 2 SECS: Seed error current status:
    0: No faulty sequence has currently been detected. If the SEIS bit is set, this means that a faulty sequence was detected and the situation has been recovered.

  Bit 1 CECS: Clock error current status:
    0: The RNG_CLK clock has been correctly detected. If the CEIS bit is set, this means that a clock error was detected and the situation has been recovered