### PR TITLE
Second bootloader support (fastflash)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,10 @@ sudo: false
 dist: trusty
 language: c
 
+env:
+  global:
+    - MAKEFLAGS=-j2
+
 addons:
   apt:
     packages:
@@ -13,7 +17,7 @@ install:
   - export PATH="$PWD/gcc-arm-none-eabi-4_9-2015q3/bin:$PATH"
 
 script:
-  - CFLAGS="-std=c99" make -C vendor/libopencm3
+  - CFLAGS="-std=c99" make -C vendor/libopencm3 lib/stm32/f2
   - make
   - make -C firmware
   - make -C bootloader

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,10 +5,12 @@ language: c
 addons:
   apt:
     packages:
-    - build-essential
-    - git
-    - gcc-arm-none-eabi
-    - libnewlib-arm-none-eabi
+      - libc6-i386
+      - make
+
+install:
+  - curl -L https://launchpad.net/gcc-arm-embedded/4.9/4.9-2015-q3-update/+download/gcc-arm-none-eabi-4_9-2015q3-20150921-linux.tar.bz2 | tar xjf -
+  - export PATH="$PWD/gcc-arm-none-eabi-4_9-2015q3/bin:$PATH"
 
 script:
   - CFLAGS="-std=c99" make -C vendor/libopencm3

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,7 +15,9 @@ script:
   - make
   - make -C firmware
   - make -C bootloader
+  - make -C fastflash
   - make -C demo
+  - make -C firmware clean && make -C firmware FASTFLASH=1
 
 notifications:
   webhooks:

--- a/bootloader/Makefile
+++ b/bootloader/Makefile
@@ -18,6 +18,3 @@ include ../Makefile.include
 
 align: $(NAME).bin
 	./firmware_align.py $(NAME).bin
-
-flash: $(NAME).bin
-	$(FLASH) write $(NAME).bin 0x8000000

--- a/fastflash/Makefile
+++ b/fastflash/Makefile
@@ -1,0 +1,13 @@
+APPVER = fastflash
+
+NAME  = bootloader
+
+OBJS += bootloader.o
+OBJS += signatures.o
+OBJS += usb.o
+
+OBJS += ../vendor/trezor-crypto/sha2.o
+
+include ../Makefile.include
+
+CFLAGS += -I../bootloader

--- a/fastflash/bootloader.c
+++ b/fastflash/bootloader.c
@@ -1,0 +1,1 @@
+../bootloader/bootloader.c

--- a/fastflash/signatures.c
+++ b/fastflash/signatures.c
@@ -1,0 +1,28 @@
+/*
+ * This file is part of the TREZOR project.
+ *
+ * Copyright (C) 2017 Saleem Rashid <trezor@saleemrashid.com>
+ *
+ * This library is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this library.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include <stdbool.h>
+#include <stdint.h>
+
+int signatures_ok(uint8_t *store_hash)
+{
+	(void) store_hash;
+
+	return false;
+}

--- a/fastflash/usb.c
+++ b/fastflash/usb.c
@@ -1,0 +1,1 @@
+../bootloader/usb.c

--- a/firmware/Makefile
+++ b/firmware/Makefile
@@ -66,7 +66,9 @@ OBJS += protob/types.pb.o
 include ../Makefile.include
 
 ifeq ($(FASTFLASH),1)
-CFLAGS += -DFASTFLASH
+CFLAGS += -DFASTFLASH=1
+else
+CFLAGS += -DFASTFLASH=0
 endif
 
 CFLAGS += -Wno-sequence-point

--- a/firmware/Makefile
+++ b/firmware/Makefile
@@ -65,3 +65,9 @@ CFLAGS += -DDEBUG_LINK=0
 CFLAGS += -DDEBUG_LOG=0
 CFLAGS += -DSCM_REVISION='"$(shell git rev-parse HEAD | sed 's:\(..\):\\x\1:g')"'
 CFLAGS += -DUSE_ETHEREUM=1
+
+bootloader.o: ../fastflash/bootloader.bin
+	$(OBJCOPY) -I binary -O elf32-littlearm -B arm \
+		--redefine-sym _binary_$(shell echo -n "$<" | tr -c "[:alnum:]" "_")_size=__bootloader_size__ \
+		--rename-section .data=.bootloader \
+		$< $@

--- a/firmware/Makefile
+++ b/firmware/Makefile
@@ -1,4 +1,11 @@
+ifeq ($(FASTFLASH),1)
+APPVER = 2.0.0
+
+OBJS += fastflash.o
+OBJS += bootloader.o
+else
 APPVER = 1.0.0
+endif
 
 NAME  = trezor
 
@@ -57,6 +64,10 @@ OBJS += protob/storage.pb.o
 OBJS += protob/types.pb.o
 
 include ../Makefile.include
+
+ifeq ($(FASTFLASH),1)
+CFLAGS += -DFASTFLASH
+endif
 
 CFLAGS += -Wno-sequence-point
 CFLAGS += -Iprotob -DPB_FIELD_16BIT=1

--- a/firmware/fastflash.c
+++ b/firmware/fastflash.c
@@ -1,0 +1,47 @@
+/*
+ * This file is part of the TREZOR project.
+ *
+ * Copyright (C) 2017 Saleem Rashid <trezor@saleemrashid.com>
+ *
+ * This library is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this library.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "fastflash.h"
+
+#include <stdbool.h>
+#include <stdint.h>
+#include <string.h>
+
+#include <libopencm3/cm3/scb.h>
+
+extern uint32_t __bootloader_loadaddr__[];
+extern uint32_t __bootloader_runaddr__[];
+extern uint8_t __bootloader_size__[];
+
+void load_bootloader() {
+	memcpy(__bootloader_runaddr__, __bootloader_loadaddr__, (size_t) __bootloader_size__);
+}
+
+void run_bootloader() {
+	// Relocate vector tables
+	SCB_VTOR = (uint32_t) __bootloader_runaddr__;
+
+	// Set stack pointer
+	__asm__ volatile("msr msp, %0":: "r" (__bootloader_runaddr__[0]));
+
+	// Jump to address
+	((void (*)(void))(__bootloader_runaddr__[1]))();
+
+	while (true);
+}

--- a/firmware/fastflash.h
+++ b/firmware/fastflash.h
@@ -1,0 +1,26 @@
+/*
+ * This file is part of the TREZOR project.
+ *
+ * Copyright (C) 2017 Saleem Rashid <trezor@saleemrashid.com>
+ *
+ * This library is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this library.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#ifndef __FASTFLASH_H__
+#define __FASTFLASH_H__
+
+void load_bootloader(void);
+void __attribute__((noreturn)) run_bootloader(void);
+
+#endif

--- a/firmware/trezor.c
+++ b/firmware/trezor.c
@@ -29,6 +29,7 @@
 #include "rng.h"
 #include "timer.h"
 #include "buttons.h"
+#include "fastflash.h"
 
 uint32_t __stack_chk_guard;
 
@@ -96,6 +97,14 @@ int main(void)
 #else
 	setupApp();
 	__stack_chk_guard = random32(); // this supports compiler provided unpredictable stack protection checks
+#endif
+
+#if FASTFLASH
+	uint16_t state = gpio_port_read(BTN_PORT);
+	if ((state & BTN_PIN_NO) == 0) {
+		load_bootloader();
+		run_bootloader();
+	}
 #endif
 
 	timer_init();

--- a/memory_app_2.0.0.ld
+++ b/memory_app_2.0.0.ld
@@ -3,8 +3,8 @@
 MEMORY
 {
 	rom (rx)        : ORIGIN = 0x08010000, LENGTH = 512K - 64K
-	bootloader (rx) : ORIGIN = 0x20000000, LENGTH = __bootloader_size__
-	ram (rwx)       : ORIGIN = ORIGIN(bootloader) + LENGTH(bootloader),
+	bootloader (rx) : ORIGIN = 0x20000000, LENGTH = 20K
+	ram (rwx)       : ORIGIN = 0x20000000 + LENGTH(bootloader),
 			  LENGTH = 128K - LENGTH(bootloader)
 }
 

--- a/memory_app_2.0.0.ld
+++ b/memory_app_2.0.0.ld
@@ -1,0 +1,21 @@
+/* STM32F205RE - 512K Flash, 128K RAM */
+/* program starts at 0x08010000 */
+MEMORY
+{
+	rom (rx)        : ORIGIN = 0x08010000, LENGTH = 512K - 64K
+	bootloader (rx) : ORIGIN = 0x20000000, LENGTH = __bootloader_size__
+	ram (rwx)       : ORIGIN = ORIGIN(bootloader) + LENGTH(bootloader),
+			  LENGTH = 128K - LENGTH(bootloader)
+}
+
+INCLUDE libopencm3_stm32f2.ld
+
+SECTIONS
+{
+	.bootloader : {
+		__bootloader_runaddr__ = .;
+		KEEP (*(.bootloader*))
+	} >bootloader AT >rom
+
+	__bootloader_loadaddr__ = LOADADDR(.bootloader);
+}

--- a/memory_app_fastflash.ld
+++ b/memory_app_fastflash.ld
@@ -2,7 +2,7 @@
 MEMORY
 {
 	rom (rx)  : ORIGIN = 0x20000000, LENGTH = 20K
-	ram (rwx) : ORIGIN = ORIGIN(rom) + LENGTH(rom),
+	ram (rwx) : ORIGIN = 0x20000000 + LENGTH(rom),
 		    LENGTH = 128K - LENGTH(rom)
 }
 

--- a/memory_app_fastflash.ld
+++ b/memory_app_fastflash.ld
@@ -1,0 +1,9 @@
+/* STM32F205RE - 512K Flash, 128K RAM */
+MEMORY
+{
+	rom (rx)  : ORIGIN = 0x20000000, LENGTH = 20K
+	ram (rwx) : ORIGIN = ORIGIN(rom) + LENGTH(rom),
+		    LENGTH = 128K - LENGTH(rom)
+}
+
+INCLUDE libopencm3_stm32f2.ld


### PR DESCRIPTION
Add second bootloader support to enable faster flashing of firmware. This is similar to @jhoenicke's [`bootloaderhack`](https://github.com/jhoenicke/trezor-mcu/tree/bootloaderhack), but has a few advantages

* It does not affect normal builds of the firmware or the bootloader (so it can be merged into `master`)
* ~~The linker script reserves exactly the size of the bootloader~~ (not compatible with GCC 4.9.3)
* The linker script avoids use of magic constants (more avoidance is possible but it breaks compatibility with GCC 4.9.3)
* The linker verifies that the bootloader fits into the reserved space
* The bootloader does not waste time verifying the signatures (and unconditionally wipes the metadata)