### PR TITLE
Fix buffer overflow in transaction.c

### DIFF
--- a/firmware/Makefile
+++ b/firmware/Makefile
@@ -29,10 +29,13 @@ OBJS += ../vendor/trezor-crypto/curves.o
 OBJS += ../vendor/trezor-crypto/secp256k1.o
 OBJS += ../vendor/trezor-crypto/nist256p1.o
 OBJS += ../vendor/trezor-crypto/ed25519-donna/ed25519.o
+OBJS += ../vendor/trezor-crypto/ed25519-donna/ed25519-sha3.o
+OBJS += ../vendor/trezor-crypto/ed25519-donna/ed25519-keccak.o
 OBJS += ../vendor/trezor-crypto/hmac.o
 OBJS += ../vendor/trezor-crypto/bip32.o
 OBJS += ../vendor/trezor-crypto/bip39.o
 OBJS += ../vendor/trezor-crypto/pbkdf2.o
+OBJS += ../vendor/trezor-crypto/base32.o
 OBJS += ../vendor/trezor-crypto/base58.o
 
 OBJS += ../vendor/trezor-crypto/ripemd160.o

--- a/firmware/transaction.c
+++ b/firmware/transaction.c
@@ -64,7 +64,7 @@ bool compute_address(const CoinType *coin,
 					 bool has_multisig, const MultisigRedeemScriptType *multisig,
 					 char address[MAX_ADDR_SIZE]) {
 
-	uint8_t raw[32];
+	uint8_t raw[34];
 	uint8_t digest[MAX_ADDR_RAW_SIZE];
 	size_t prelen;
 


### PR DESCRIPTION
Can't take all the credit for this, it was detected by GCC 7.1.0