### PR TITLE
Set -mcpu=cortex-m3 linker flag.

### DIFF
--- a/Makefile.include
+++ b/Makefile.include
@@ -71,9 +71,8 @@ LDFLAGS  += --static \
             -T$(LDSCRIPT) \
             -nostartfiles \
             -Wl,--gc-sections \
+            -mcpu=cortex-m3 \
             -mthumb \
-            -march=armv7 \
-            -mfix-cortex-m3-ldrd \
             -msoft-float
 
 all: $(NAME).bin


### PR DESCRIPTION
This fixes a bug with Ubuntu 17.04.
It includes the correct architecture (armv7-m) and also includes the flag -mfix-cortex-m3-ldrd as default.