### PR TITLE
Deferred backup

### DIFF
--- a/firmware/fsm.c
+++ b/firmware/fsm.c
@@ -234,6 +234,7 @@ void fsm_msgGetFeatures(GetFeatures *msg)
 	resp->has_imported = true; resp->imported = storage.has_imported && storage.imported;
 	resp->has_pin_cached = true; resp->pin_cached = session_isPinCached();
 	resp->has_passphrase_cached = true; resp->passphrase_cached = session_isPassphraseCached();
+	resp->has_needs_backup = true; resp->needs_backup = storage_needsBackup();
 	msg_write(MessageType_MessageType_Features, resp);
 }
 

--- a/firmware/fsm.c
+++ b/firmware/fsm.c
@@ -453,7 +453,7 @@ void fsm_msgBackupDevice(BackupDevice *msg)
 	CHECK_INITIALIZED
 
 	(void)msg;
-	reset_backup();
+	reset_backup(true);
 }
 
 void fsm_msgSignTx(SignTx *msg)

--- a/firmware/fsm.c
+++ b/firmware/fsm.c
@@ -442,8 +442,17 @@ void fsm_msgResetDevice(ResetDevice *msg)
 		msg->has_pin_protection && msg->pin_protection,
 		msg->has_language ? msg->language : 0,
 		msg->has_label ? msg->label : 0,
-		msg->has_u2f_counter ? msg->u2f_counter : 0
+		msg->has_u2f_counter ? msg->u2f_counter : 0,
+		msg->has_skip_backup ? msg->skip_backup : false
 	);
+}
+
+void fsm_msgBackupDevice(BackupDevice *msg)
+{
+	CHECK_INITIALIZED
+
+	(void)msg;
+	reset_backup();
 }
 
 void fsm_msgSignTx(SignTx *msg)

--- a/firmware/fsm.h
+++ b/firmware/fsm.h
@@ -36,6 +36,7 @@ void fsm_msgGetEntropy(GetEntropy *msg);
 void fsm_msgGetPublicKey(GetPublicKey *msg);
 void fsm_msgLoadDevice(LoadDevice *msg);
 void fsm_msgResetDevice(ResetDevice *msg);
+void fsm_msgBackupDevice(BackupDevice *msg);
 void fsm_msgSignTx(SignTx *msg);
 //void fsm_msgPinMatrixAck(PinMatrixAck *msg);
 void fsm_msgCancel(Cancel *msg);

--- a/firmware/layout2.c
+++ b/firmware/layout2.c
@@ -83,6 +83,10 @@ void layoutHome(void)
 			oledDrawBitmap(40, 0, &bmp_logo64);
 		}
 	}
+	if (storage_needsBackup()) {
+		oledBox(0, 0, 127, 8, false);
+		oledDrawStringCenter(0, "NEEDS BACKUP!");
+	}
 	oledRefresh();
 
 	// Reset lock screen timeout

--- a/firmware/protob/messages.pb.c
+++ b/firmware/protob/messages.pb.c
@@ -26,7 +26,7 @@ const pb_field_t GetFeatures_fields[1] = {
     PB_LAST_FIELD
 };
 
-const pb_field_t Features_fields[19] = {
+const pb_field_t Features_fields[20] = {
     PB_FIELD2(  1, STRING  , OPTIONAL, STATIC  , FIRST, Features, vendor, vendor, 0),
     PB_FIELD2(  2, UINT32  , OPTIONAL, STATIC  , OTHER, Features, major_version, vendor, 0),
     PB_FIELD2(  3, UINT32  , OPTIONAL, STATIC  , OTHER, Features, minor_version, major_version, 0),
@@ -45,6 +45,7 @@ const pb_field_t Features_fields[19] = {
     PB_FIELD2( 16, BOOL    , OPTIONAL, STATIC  , OTHER, Features, pin_cached, imported, 0),
     PB_FIELD2( 17, BOOL    , OPTIONAL, STATIC  , OTHER, Features, passphrase_cached, pin_cached, 0),
     PB_FIELD2( 18, BOOL    , OPTIONAL, STATIC  , OTHER, Features, firmware_present, passphrase_cached, 0),
+    PB_FIELD2( 19, BOOL    , OPTIONAL, STATIC  , OTHER, Features, needs_backup, firmware_present, 0),
     PB_LAST_FIELD
 };
 

--- a/firmware/protob/messages.pb.c
+++ b/firmware/protob/messages.pb.c
@@ -182,7 +182,7 @@ const pb_field_t LoadDevice_fields[9] = {
     PB_LAST_FIELD
 };
 
-const pb_field_t ResetDevice_fields[8] = {
+const pb_field_t ResetDevice_fields[9] = {
     PB_FIELD2(  1, BOOL    , OPTIONAL, STATIC  , FIRST, ResetDevice, display_random, display_random, 0),
     PB_FIELD2(  2, UINT32  , OPTIONAL, STATIC  , OTHER, ResetDevice, strength, display_random, &ResetDevice_strength_default),
     PB_FIELD2(  3, BOOL    , OPTIONAL, STATIC  , OTHER, ResetDevice, passphrase_protection, strength, 0),
@@ -190,6 +190,11 @@ const pb_field_t ResetDevice_fields[8] = {
     PB_FIELD2(  5, STRING  , OPTIONAL, STATIC  , OTHER, ResetDevice, language, pin_protection, &ResetDevice_language_default),
     PB_FIELD2(  6, STRING  , OPTIONAL, STATIC  , OTHER, ResetDevice, label, language, 0),
     PB_FIELD2(  7, UINT32  , OPTIONAL, STATIC  , OTHER, ResetDevice, u2f_counter, label, 0),
+    PB_FIELD2(  8, BOOL    , OPTIONAL, STATIC  , OTHER, ResetDevice, skip_backup, u2f_counter, 0),
+    PB_LAST_FIELD
+};
+
+const pb_field_t BackupDevice_fields[1] = {
     PB_LAST_FIELD
 };
 
@@ -420,7 +425,7 @@ const pb_field_t DebugLinkFlashErase_fields[2] = {
  * numbers or field sizes that are larger than what can fit in 8 or 16 bit
  * field descriptors.
  */
-STATIC_ASSERT((pb_membersize(Features, coins[0]) < 65536 && pb_membersize(PublicKey, node) < 65536 && pb_membersize(GetAddress, multisig) < 65536 && pb_membersize(LoadDevice, node) < 65536 && pb_membersize(TxRequest, details) < 65536 && pb_membersize(TxRequest, serialized) < 65536 && pb_membersize(TxAck, tx) < 65536 && pb_membersize(SignIdentity, identity) < 65536 && pb_membersize(GetECDHSessionKey, identity) < 65536 && pb_membersize(DebugLinkState, node) < 65536), YOU_MUST_DEFINE_PB_FIELD_32BIT_FOR_MESSAGES_Initialize_GetFeatures_Features_ClearSession_ApplySettings_ChangePin_Ping_Success_Failure_ButtonRequest_ButtonAck_PinMatrixRequest_PinMatrixAck_Cancel_PassphraseRequest_PassphraseAck_GetEntropy_Entropy_GetPublicKey_PublicKey_GetAddress_EthereumGetAddress_Address_EthereumAddress_WipeDevice_LoadDevice_ResetDevice_EntropyRequest_EntropyAck_RecoveryDevice_WordRequest_WordAck_SignMessage_VerifyMessage_MessageSignature_CipherKeyValue_CipheredKeyValue_EstimateTxSize_TxSize_SignTx_TxRequest_TxAck_EthereumSignTx_EthereumTxRequest_EthereumTxAck_SignIdentity_SignedIdentity_GetECDHSessionKey_ECDHSessionKey_SetU2FCounter_DebugLinkDecision_DebugLinkGetState_DebugLinkState_DebugLinkStop_DebugLinkLog_DebugLinkMemoryRead_DebugLinkMemory_DebugLinkMemoryWrite_DebugLinkFlashErase)
+STATIC_ASSERT((pb_membersize(Features, coins[0]) < 65536 && pb_membersize(PublicKey, node) < 65536 && pb_membersize(GetAddress, multisig) < 65536 && pb_membersize(LoadDevice, node) < 65536 && pb_membersize(TxRequest, details) < 65536 && pb_membersize(TxRequest, serialized) < 65536 && pb_membersize(TxAck, tx) < 65536 && pb_membersize(SignIdentity, identity) < 65536 && pb_membersize(GetECDHSessionKey, identity) < 65536 && pb_membersize(DebugLinkState, node) < 65536), YOU_MUST_DEFINE_PB_FIELD_32BIT_FOR_MESSAGES_Initialize_GetFeatures_Features_ClearSession_ApplySettings_ChangePin_Ping_Success_Failure_ButtonRequest_ButtonAck_PinMatrixRequest_PinMatrixAck_Cancel_PassphraseRequest_PassphraseAck_GetEntropy_Entropy_GetPublicKey_PublicKey_GetAddress_EthereumGetAddress_Address_EthereumAddress_WipeDevice_LoadDevice_ResetDevice_BackupDevice_EntropyRequest_EntropyAck_RecoveryDevice_WordRequest_WordAck_SignMessage_VerifyMessage_MessageSignature_CipherKeyValue_CipheredKeyValue_EstimateTxSize_TxSize_SignTx_TxRequest_TxAck_EthereumSignTx_EthereumTxRequest_EthereumTxAck_SignIdentity_SignedIdentity_GetECDHSessionKey_ECDHSessionKey_SetU2FCounter_DebugLinkDecision_DebugLinkGetState_DebugLinkState_DebugLinkStop_DebugLinkLog_DebugLinkMemoryRead_DebugLinkMemory_DebugLinkMemoryWrite_DebugLinkFlashErase)
 #endif
 
 #if !defined(PB_FIELD_16BIT) && !defined(PB_FIELD_32BIT)

--- a/firmware/protob/messages.pb.h
+++ b/firmware/protob/messages.pb.h
@@ -42,6 +42,7 @@ typedef enum _MessageType {
     MessageType_MessageType_ButtonAck = 27,
     MessageType_MessageType_GetAddress = 29,
     MessageType_MessageType_Address = 30,
+    MessageType_MessageType_BackupDevice = 34,
     MessageType_MessageType_EntropyRequest = 35,
     MessageType_MessageType_EntropyAck = 36,
     MessageType_MessageType_SignMessage = 38,
@@ -82,6 +83,10 @@ typedef enum _MessageType {
 } MessageType;
 
 /* Struct definitions */
+typedef struct _BackupDevice {
+    uint8_t dummy_field;
+} BackupDevice;
+
 typedef struct _ButtonAck {
     uint8_t dummy_field;
 } ButtonAck;
@@ -602,6 +607,8 @@ typedef struct _ResetDevice {
     char label[33];
     bool has_u2f_counter;
     uint32_t u2f_counter;
+    bool has_skip_backup;
+    bool skip_backup;
 } ResetDevice;
 
 typedef struct _SetU2FCounter {
@@ -764,7 +771,8 @@ extern const uint32_t SignTx_lock_time_default;
 #define EthereumAddress_init_default             {{0, {0}}}
 #define WipeDevice_init_default                  {0}
 #define LoadDevice_init_default                  {false, "", false, HDNodeType_init_default, false, "", false, 0, false, "english", false, "", false, 0, false, 0}
-#define ResetDevice_init_default                 {false, 0, false, 256u, false, 0, false, 0, false, "english", false, "", false, 0}
+#define ResetDevice_init_default                 {false, 0, false, 256u, false, 0, false, 0, false, "english", false, "", false, 0, false, 0}
+#define BackupDevice_init_default                {0}
 #define EntropyRequest_init_default              {0}
 #define EntropyAck_init_default                  {false, {0, {0}}}
 #define RecoveryDevice_init_default              {false, 0, false, 0, false, 0, false, "english", false, "", false, 0, false, 0, false, 0, false, 0}
@@ -823,7 +831,8 @@ extern const uint32_t SignTx_lock_time_default;
 #define EthereumAddress_init_zero                {{0, {0}}}
 #define WipeDevice_init_zero                     {0}
 #define LoadDevice_init_zero                     {false, "", false, HDNodeType_init_zero, false, "", false, 0, false, "", false, "", false, 0, false, 0}
-#define ResetDevice_init_zero                    {false, 0, false, 0, false, 0, false, 0, false, "", false, "", false, 0}
+#define ResetDevice_init_zero                    {false, 0, false, 0, false, 0, false, 0, false, "", false, "", false, 0, false, 0}
+#define BackupDevice_init_zero                   {0}
 #define EntropyRequest_init_zero                 {0}
 #define EntropyAck_init_zero                     {false, {0, {0}}}
 #define RecoveryDevice_init_zero                 {false, 0, false, 0, false, 0, false, "", false, "", false, 0, false, 0, false, 0, false, 0}
@@ -986,6 +995,7 @@ extern const uint32_t SignTx_lock_time_default;
 #define ResetDevice_language_tag                 5
 #define ResetDevice_label_tag                    6
 #define ResetDevice_u2f_counter_tag              7
+#define ResetDevice_skip_backup_tag              8
 #define SetU2FCounter_u2f_counter_tag            1
 #define SignIdentity_identity_tag                1
 #define SignIdentity_challenge_hidden_tag        2
@@ -1042,7 +1052,8 @@ extern const pb_field_t Address_fields[2];
 extern const pb_field_t EthereumAddress_fields[2];
 extern const pb_field_t WipeDevice_fields[1];
 extern const pb_field_t LoadDevice_fields[9];
-extern const pb_field_t ResetDevice_fields[8];
+extern const pb_field_t ResetDevice_fields[9];
+extern const pb_field_t BackupDevice_fields[1];
 extern const pb_field_t EntropyRequest_fields[1];
 extern const pb_field_t EntropyAck_fields[2];
 extern const pb_field_t RecoveryDevice_fields[10];
@@ -1103,7 +1114,8 @@ extern const pb_field_t DebugLinkFlashErase_fields[2];
 #define EthereumAddress_size                     22
 #define WipeDevice_size                          0
 #define LoadDevice_size                          (326 + HDNodeType_size)
-#define ResetDevice_size                         72
+#define ResetDevice_size                         74
+#define BackupDevice_size                        0
 #define EntropyRequest_size                      0
 #define EntropyAck_size                          131
 #define RecoveryDevice_size                      80

--- a/firmware/protob/messages.pb.h
+++ b/firmware/protob/messages.pb.h
@@ -466,6 +466,8 @@ typedef struct _Features {
     bool passphrase_cached;
     bool has_firmware_present;
     bool firmware_present;
+    bool has_needs_backup;
+    bool needs_backup;
 } Features;
 
 typedef struct _GetAddress {
@@ -747,7 +749,7 @@ extern const uint32_t SignTx_lock_time_default;
 /* Initializer values for message structs */
 #define Initialize_init_default                  {0}
 #define GetFeatures_init_default                 {0}
-#define Features_init_default                    {false, "", false, 0, false, 0, false, 0, false, 0, false, "", false, 0, false, 0, false, "", false, "", 0, {CoinType_init_default, CoinType_init_default, CoinType_init_default, CoinType_init_default, CoinType_init_default, CoinType_init_default, CoinType_init_default, CoinType_init_default}, false, 0, false, {0, {0}}, false, {0, {0}}, false, 0, false, 0, false, 0, false, 0}
+#define Features_init_default                    {false, "", false, 0, false, 0, false, 0, false, 0, false, "", false, 0, false, 0, false, "", false, "", 0, {CoinType_init_default, CoinType_init_default, CoinType_init_default, CoinType_init_default, CoinType_init_default, CoinType_init_default, CoinType_init_default, CoinType_init_default}, false, 0, false, {0, {0}}, false, {0, {0}}, false, 0, false, 0, false, 0, false, 0, false, 0}
 #define ClearSession_init_default                {0}
 #define ApplySettings_init_default               {false, "", false, "", false, 0, false, {0, {0}}}
 #define ChangePin_init_default                   {false, 0}
@@ -807,7 +809,7 @@ extern const uint32_t SignTx_lock_time_default;
 #define DebugLinkFlashErase_init_default         {false, 0}
 #define Initialize_init_zero                     {0}
 #define GetFeatures_init_zero                    {0}
-#define Features_init_zero                       {false, "", false, 0, false, 0, false, 0, false, 0, false, "", false, 0, false, 0, false, "", false, "", 0, {CoinType_init_zero, CoinType_init_zero, CoinType_init_zero, CoinType_init_zero, CoinType_init_zero, CoinType_init_zero, CoinType_init_zero, CoinType_init_zero}, false, 0, false, {0, {0}}, false, {0, {0}}, false, 0, false, 0, false, 0, false, 0}
+#define Features_init_zero                       {false, "", false, 0, false, 0, false, 0, false, 0, false, "", false, 0, false, 0, false, "", false, "", 0, {CoinType_init_zero, CoinType_init_zero, CoinType_init_zero, CoinType_init_zero, CoinType_init_zero, CoinType_init_zero, CoinType_init_zero, CoinType_init_zero}, false, 0, false, {0, {0}}, false, {0, {0}}, false, 0, false, 0, false, 0, false, 0, false, 0}
 #define ClearSession_init_zero                   {0}
 #define ApplySettings_init_zero                  {false, "", false, "", false, 0, false, {0, {0}}}
 #define ChangePin_init_zero                      {false, 0}
@@ -947,6 +949,7 @@ extern const uint32_t SignTx_lock_time_default;
 #define Features_pin_cached_tag                  16
 #define Features_passphrase_cached_tag           17
 #define Features_firmware_present_tag            18
+#define Features_needs_backup_tag                19
 #define GetAddress_address_n_tag                 1
 #define GetAddress_coin_name_tag                 2
 #define GetAddress_show_display_tag              3
@@ -1028,7 +1031,7 @@ extern const uint32_t SignTx_lock_time_default;
 /* Struct field encoding specification for nanopb */
 extern const pb_field_t Initialize_fields[1];
 extern const pb_field_t GetFeatures_fields[1];
-extern const pb_field_t Features_fields[19];
+extern const pb_field_t Features_fields[20];
 extern const pb_field_t ClearSession_fields[1];
 extern const pb_field_t ApplySettings_fields[5];
 extern const pb_field_t ChangePin_fields[2];
@@ -1090,7 +1093,7 @@ extern const pb_field_t DebugLinkFlashErase_fields[2];
 /* Maximum encoded size of messages (where known) */
 #define Initialize_size                          0
 #define GetFeatures_size                         0
-#define Features_size                            (257 + 8*CoinType_size)
+#define Features_size                            (260 + 8*CoinType_size)
 #define ClearSession_size                        0
 #define ApplySettings_size                       1083
 #define ChangePin_size                           2

--- a/firmware/protob/messages_map.h
+++ b/firmware/protob/messages_map.h
@@ -22,6 +22,7 @@
 	{ 'n', 'i', MessageType_MessageType_ApplySettings,         ApplySettings_fields,         (void (*)(void *)) fsm_msgApplySettings },
 	// Message ButtonAck is used in tiny mode
 	{ 'n', 'i', MessageType_MessageType_GetAddress,            GetAddress_fields,            (void (*)(void *)) fsm_msgGetAddress },
+	{ 'n', 'i', MessageType_MessageType_BackupDevice,          BackupDevice_fields,          (void (*)(void *)) fsm_msgBackupDevice },
 	{ 'n', 'i', MessageType_MessageType_EntropyAck,            EntropyAck_fields,            (void (*)(void *)) fsm_msgEntropyAck },
 	{ 'n', 'i', MessageType_MessageType_SignMessage,           SignMessage_fields,           (void (*)(void *)) fsm_msgSignMessage },
 	{ 'n', 'i', MessageType_MessageType_VerifyMessage,         VerifyMessage_fields,         (void (*)(void *)) fsm_msgVerifyMessage },

--- a/firmware/protob/storage.pb.c
+++ b/firmware/protob/storage.pb.c
@@ -5,7 +5,7 @@
 
 
 
-const pb_field_t Storage_fields[12] = {
+const pb_field_t Storage_fields[13] = {
     PB_FIELD2(  1, UINT32  , REQUIRED, STATIC  , FIRST, Storage, version, version, 0),
     PB_FIELD2(  2, MESSAGE , OPTIONAL, STATIC  , OTHER, Storage, node, version, &HDNodeType_fields),
     PB_FIELD2(  3, STRING  , OPTIONAL, STATIC  , OTHER, Storage, mnemonic, node, 0),
@@ -17,6 +17,7 @@ const pb_field_t Storage_fields[12] = {
     PB_FIELD2(  9, BOOL    , OPTIONAL, STATIC  , OTHER, Storage, imported, label, 0),
     PB_FIELD2( 10, BYTES   , OPTIONAL, STATIC  , OTHER, Storage, homescreen, imported, 0),
     PB_FIELD2( 11, UINT32  , OPTIONAL, STATIC  , OTHER, Storage, u2f_counter, homescreen, 0),
+    PB_FIELD2( 12, BOOL    , OPTIONAL, STATIC  , OTHER, Storage, needs_backup, u2f_counter, 0),
     PB_LAST_FIELD
 };
 

--- a/firmware/protob/storage.pb.h
+++ b/firmware/protob/storage.pb.h
@@ -39,13 +39,15 @@ typedef struct _Storage {
     Storage_homescreen_t homescreen;
     bool has_u2f_counter;
     uint32_t u2f_counter;
+    bool has_needs_backup;
+    bool needs_backup;
 } Storage;
 
 /* Default values for struct fields */
 
 /* Initializer values for message structs */
-#define Storage_init_default                     {0, false, HDNodeType_init_default, false, "", false, 0, false, 0, false, "", false, "", false, "", false, 0, false, {0, {0}}, false, 0}
-#define Storage_init_zero                        {0, false, HDNodeType_init_zero, false, "", false, 0, false, 0, false, "", false, "", false, "", false, 0, false, {0, {0}}, false, 0}
+#define Storage_init_default                     {0, false, HDNodeType_init_default, false, "", false, 0, false, 0, false, "", false, "", false, "", false, 0, false, {0, {0}}, false, 0, false, 0}
+#define Storage_init_zero                        {0, false, HDNodeType_init_zero, false, "", false, 0, false, 0, false, "", false, "", false, "", false, 0, false, {0, {0}}, false, 0, false, 0}
 
 /* Field tags (for use in manual encoding/decoding) */
 #define Storage_version_tag                      1
@@ -59,12 +61,13 @@ typedef struct _Storage {
 #define Storage_imported_tag                     9
 #define Storage_homescreen_tag                   10
 #define Storage_u2f_counter_tag                  11
+#define Storage_needs_backup_tag                 12
 
 /* Struct field encoding specification for nanopb */
-extern const pb_field_t Storage_fields[12];
+extern const pb_field_t Storage_fields[13];
 
 /* Maximum encoded size of messages (where known) */
-#define Storage_size                             (1365 + HDNodeType_size)
+#define Storage_size                             (1367 + HDNodeType_size)
 
 #ifdef __cplusplus
 } /* extern "C" */

--- a/firmware/recovery.c
+++ b/firmware/recovery.c
@@ -179,7 +179,7 @@ static void recovery_done(void) {
 				_("The seed is"), _("INVALID!"), NULL, NULL, NULL, NULL);
 			protectButton(ButtonRequestType_ButtonRequest_Other, true);
 		}
-		fsm_sendFailure(FailureType_Failure_DataError, _("Invalid mnemonic, are words in correct order?"));
+		fsm_sendFailure(FailureType_Failure_DataError, _("Invalid seed, are words in correct order?"));
 	}
 	awaiting_word = 0;
 	layoutHome();

--- a/firmware/reset.c
+++ b/firmware/reset.c
@@ -110,7 +110,7 @@ static char current_word[10], current_word_display[11];
 
 void reset_backup(void)
 {
-	if (!storage.has_needs_backup || !storage.needs_backup) {
+	if (!storage_needsBackup()) {
 		fsm_sendFailure(FailureType_Failure_UnexpectedMessage, _("Seed already backed up"));
 		return;
 	} else {

--- a/firmware/reset.c
+++ b/firmware/reset.c
@@ -114,7 +114,7 @@ void reset_backup(void)
 		fsm_sendFailure(FailureType_Failure_UnexpectedMessage, _("Seed already backed up"));
 		return;
 	} else {
-		storage.has_needs_backup = false;
+		storage.has_needs_backup = true;
 		storage.needs_backup = false;
 		storage_commit();
 	}

--- a/firmware/reset.c
+++ b/firmware/reset.c
@@ -33,12 +33,14 @@
 static uint32_t strength;
 static uint8_t  int_entropy[32];
 static bool     awaiting_entropy = false;
+static bool     skip_backup = false;
 
-void reset_init(bool display_random, uint32_t _strength, bool passphrase_protection, bool pin_protection, const char *language, const char *label, uint32_t u2f_counter)
+void reset_init(bool display_random, uint32_t _strength, bool passphrase_protection, bool pin_protection, const char *language, const char *label, uint32_t u2f_counter, bool _skip_backup)
 {
 	if (_strength != 128 && _strength != 192 && _strength != 256) return;
 
 	strength = _strength;
+	skip_backup = _skip_backup;
 
 	random_buffer(int_entropy, 32);
 
@@ -75,8 +77,6 @@ void reset_init(bool display_random, uint32_t _strength, bool passphrase_protect
 	awaiting_entropy = true;
 }
 
-static char current_word[10], current_word_display[11];
-
 void reset_entropy(const uint8_t *ext_entropy, uint32_t len)
 {
 	if (!awaiting_entropy) {
@@ -91,6 +91,33 @@ void reset_entropy(const uint8_t *ext_entropy, uint32_t len)
 	strlcpy(storage.mnemonic, mnemonic_from_data(int_entropy, strength / 8), sizeof(storage.mnemonic));
 	memset(int_entropy, 0, 32);
 	awaiting_entropy = false;
+
+	storage.has_mnemonic = true;
+	storage.has_needs_backup = true;
+	storage.needs_backup = true;
+
+	if (skip_backup) {
+		storage_commit();
+		fsm_sendSuccess(_("Device successfully initialized"));
+		layoutHome();
+	} else {
+		reset_backup();
+	}
+
+}
+
+static char current_word[10], current_word_display[11];
+
+void reset_backup(void)
+{
+	if (!storage.has_needs_backup || !storage.needs_backup) {
+		fsm_sendFailure(FailureType_Failure_UnexpectedMessage, _("Seed already backed up"));
+		return;
+	} else {
+		storage.has_needs_backup = false;
+		storage.needs_backup = false;
+		storage_commit();
+	}
 
 	int pass, word_pos, i = 0, j;
 
@@ -146,10 +173,7 @@ void reset_entropy(const uint8_t *ext_entropy, uint32_t len)
 			}
 		}
 	}
-
-	storage.has_mnemonic = true;
-	storage_commit();
-	fsm_sendSuccess(_("Device reset"));
+	fsm_sendSuccess(_("Seed successfully backed up"));
 	layoutHome();
 }
 

--- a/firmware/reset.h
+++ b/firmware/reset.h
@@ -25,7 +25,7 @@
 
 void reset_init(bool display_random, uint32_t _strength, bool passphrase_protection, bool pin_protection, const char *language, const char *label, uint32_t u2f_counter, bool skip_backup);
 void reset_entropy(const uint8_t *ext_entropy, uint32_t len);
-void reset_backup(void);
+void reset_backup(bool separated);
 uint32_t reset_get_int_entropy(uint8_t *entropy);
 const char *reset_get_word(void);
 

--- a/firmware/reset.h
+++ b/firmware/reset.h
@@ -23,8 +23,9 @@
 #include <stdint.h>
 #include <stdbool.h>
 
-void reset_init(bool display_random, uint32_t _strength, bool passphrase_protection, bool pin_protection, const char *language, const char *label, uint32_t u2f_counter);
+void reset_init(bool display_random, uint32_t _strength, bool passphrase_protection, bool pin_protection, const char *language, const char *label, uint32_t u2f_counter, bool skip_backup);
 void reset_entropy(const uint8_t *ext_entropy, uint32_t len);
+void reset_backup(void);
 uint32_t reset_get_int_entropy(uint8_t *entropy);
 const char *reset_get_word(void);
 

--- a/firmware/storage.c
+++ b/firmware/storage.c
@@ -580,6 +580,12 @@ bool storage_isInitialized(void)
 	return storage.has_node || storage.has_mnemonic;
 }
 
+bool storage_needsBackup(void)
+{
+	return storage.has_needs_backup && storage.needs_backup;
+}
+
+
 uint32_t storage_nextU2FCounter(void)
 {
 	uint32_t *ptr = ((uint32_t *) FLASH_STORAGE_U2FAREA) + (storage_u2f_offset / 32);

--- a/firmware/storage.h
+++ b/firmware/storage.h
@@ -68,6 +68,8 @@ void storage_setU2FCounter(uint32_t u2fcounter);
 
 bool storage_isInitialized(void);
 
+bool storage_needsBackup(void);
+
 extern Storage storage;
 
 extern char storage_uuid_str[25];


### PR DESCRIPTION
We'd like to make backup workflow independent from initialization.

When ResetDevice message contains field skip_backup=true, it will not do the backup, but rather set a field needs_backup=true in Storage.

Later user can invoke backup using BackupDevice message which will setup needs_backup back to false to avoid multiple invocations of this workflow.

When ResetDevice does not contain this field, original behavior is expected.

@jhoenicke @saleemrashid could you please check whether I got everything allright?