### PR TITLE
add ability for developers to easily avoid locking their flash memory

### DIFF
--- a/Makefile.include
+++ b/Makefile.include
@@ -59,6 +59,12 @@ else
 LDSCRIPT  = $(TOP_DIR)/memory.ld
 endif
 
+ifeq ($(MEMORY_PROTECT), 0)
+CFLAGS += -DMEMORY_PROTECT=0
+else
+CFLAGS += -DMEMORY_PROTECT=1
+endif
+
 LDFLAGS  += --static \
             -Wl,--start-group \
             -lc \

--- a/memory.c
+++ b/memory.c
@@ -27,6 +27,7 @@
 
 void memory_protect(void)
 {
+#if MEMORY_PROTECT
 	// Reference STM32F205 Flash programming manual revision 5 http://www.st.com/resource/en/programming_manual/cd00233952.pdf
 	// Section 2.6 Option bytes
 	//                     set RDP level 2                   WRP for sectors 0 and 1
@@ -45,6 +46,7 @@ void memory_protect(void)
 	//   Bit 0 OPTLOCK: Option lock: ignored by flash_program_option_bytes
 	flash_program_option_bytes(0x0FFCCCEC);
 	flash_lock_option_bytes();
+#endif
 }
 
 int memory_bootloader_hash(uint8_t *hash)


### PR DESCRIPTION
This PR adds the ability for developers to easily compile a bootloader that won't lock the bootloader flash memory sectors on their dev board :)

The default is still to lock them. This is just a manual override.

verified the generated code with:
```
make clean && make && arm-none-eabi-objdump -d memory.o
make clean && make MEMORY_PROTECT=1 && arm-none-eabi-objdump -d memory.o
make clean && make MEMORY_PROTECT=0 && arm-none-eabi-objdump -d memory.o
```