### PR TITLE
fix bootloader stack protector fault

### DIFF
--- a/bootloader/bootloader.c
+++ b/bootloader/bootloader.c
@@ -76,12 +76,15 @@ void show_unofficial_warning(const uint8_t *hash)
 	// everything is OK, user pressed 2x Continue -> continue program
 }
 
-void load_app(void)
+void __attribute__((noreturn)) load_app(void)
 {
 	// jump to app
 	SCB_VTOR = FLASH_APP_START; // & 0xFFFF;
 	__asm__ volatile("msr msp, %0"::"g" (*(volatile uint32_t *)FLASH_APP_START));
 	(*(void (**)())(FLASH_APP_START + 4))();
+	// forever loop to indicate to the compiler that this function does not return.
+	// this avoids the stack protector injecting code that faults with the new stack.
+	for (;;);
 }
 
 bool firmware_present(void)


### PR DESCRIPTION
My compiler was generating this code for the load_app function with the stack protector on:
```
   |0x80002e4 <load_app>    push   {r0, r1, r2, lr}                                                                                                    │
   │0x80002e6 <load_app+2>  ldr    r3, [pc, #40]   ; (0x8000310 <load_app+44>)                                                                         │
   │0x80002e8 <load_app+4>  ldr    r1, [pc, #40]   ; (0x8000314 <load_app+48>)                                                                         │
   │0x80002ea <load_app+6>  ldr    r2, [r3, #0]                                                                                                        │
   │0x80002ec <load_app+8>  str    r2, [sp, #4]                                                                                                        │
   │0x80002ee <load_app+10> ldr    r2, [pc, #40]   ; (0x8000318 <load_app+52>)                                                                         │
   │0x80002f0 <load_app+12> str    r2, [r1, #0]                                                                                                        │
   │0x80002f2 <load_app+14> ldr    r2, [r2, #0]                                                                                                        │
   │0x80002f4 <load_app+16> msr    MSP, r2                                                                                                             │
  >│0x80002f8 <load_app+20> ldr    r2, [sp, #4]                                                                                                        │
   │0x80002fa <load_app+22> ldr    r3, [r3, #0]                                                                                                        │
   │0x80002fc <load_app+24> cmp    r2, r3                                                                                                              │
   │0x80002fe <load_app+26> beq.n  0x8000304 <load_app+32>                                                                                             │
   │0x8000300 <load_app+28> bl     0x800042c <__stack_chk_fail>                                                                                        │
   │0x8000304 <load_app+32> ldr    r3, [pc, #20]   ; (0x800031c <load_app+56>)                                                                         │
   │0x8000306 <load_app+34> ldr    r3, [r3, #0]                                                                                                        │
   │0x8000308 <load_app+36> add    sp, #12                                                                                                             │
   │0x800030a <load_app+38> ldr.w  lr, [sp], #4                                                                                                        │
   │0x800030e <load_app+42> bx     r3
```

**The bug is that the compiler is adding in the stack protector code before our branch to the firmware. So, instead of changing the MSP to point to the end of SRAM and then immediately branching (without accessing the new stack), the compiler generated stack protector code is getting injected and indexing past the end of SRAM, causing a cpu _fault_.**

I don't think this is a compiler bug. What we're doing is probably undefined behavior. So, we need to fix that somehow.

Turning off the stack protector, we get this code generated. But this didn't have stack protection:
```
   |0x80002a8 <load_app>                    ldr    r3, [pc, #16]   ; (0x80002bc <load_app+20>)                                                         │
   │0x80002aa <load_app+2>                  ldr    r2, [pc, #20]   ; (0x80002c0 <load_app+24>)                                                         │
   │0x80002ac <load_app+4>                  str    r3, [r2, #0]                                                                                        │
   │0x80002ae <load_app+6>                  ldr    r3, [r3, #0]                                                                                        │
   │0x80002b0 <load_app+8>                  msr    MSP, r3                                                                                             │
  >│0x80002b4 <load_app+12>                 ldr    r3, [pc, #12]   ; (0x80002c4 <load_app+28>)                                                         │
   │0x80002b6 <load_app+14>                 ldr    r3, [r3, #0]                                                                                        │
   │0x80002b8 <load_app+16>                 bx     r3
```

This final code listing was generated when my "fix" was applied:
```
   |0x80002e4 <load_app>    push   {r7, lr}                                                                                                            │
   │0x80002e6 <load_app+2>  sub    sp, #8                                                                                                              │
   │0x80002e8 <load_app+4>  add    r7, sp, #0                                                                                                          │
   │0x80002ea <load_app+6>  ldr    r3, [pc, #44]   ; (0x8000318 <load_app+52>)                                                                         │
   │0x80002ec <load_app+8>  ldr    r3, [r3, #0]                                                                                                        │
   │0x80002ee <load_app+10> str    r3, [r7, #4]                                                                                                        │
   │0x80002f0 <load_app+12> ldr    r3, [pc, #40]   ; (0x800031c <load_app+56>)                                                                         │
   │0x80002f2 <load_app+14> ldr    r2, [pc, #44]   ; (0x8000320 <load_app+60>)                                                                         │
   │0x80002f4 <load_app+16> str    r2, [r3, #0]                                                                                                        │
   │0x80002f6 <load_app+18> ldr    r3, [pc, #40]   ; (0x8000320 <load_app+60>)                                                                         │
   │0x80002f8 <load_app+20> ldr    r3, [r3, #0]                                                                                                        │
   │0x80002fa <load_app+22> msr    MSP, r3                                                                                                             │
   │0x80002fe <load_app+26> ldr    r3, [pc, #36]   ; (0x8000324 <load_app+64>)                                                                         │
   │0x8000300 <load_app+28> ldr    r3, [r3, #0]                                                                                                        │
   │0x8000302 <load_app+30> blx    r3                                                                                                                  │
   │0x8000304 <load_app+32> ldr    r3, [pc, #16]   ; (0x8000318 <load_app+52>)                                                                         │
   │0x8000306 <load_app+34> ldr    r2, [r7, #4]                                                                                                        │
   │0x8000308 <load_app+36> ldr    r3, [r3, #0]                                                                                                        │
   │0x800030a <load_app+38> cmp    r2, r3                                                                                                              │
   │0x800030c <load_app+40> beq.n  0x8000312 <load_app+46>                                                                                             │
   │0x800030e <load_app+42> bl     0x8000434 <__stack_chk_fail>
...
```

In summary, the generated code now works correctly. At least, it does for my version of the compiler. Maybe you can think of a better fix? But, for the moment at least, this small change seems to work. Maybe the load_app function just needs to be broken out into an assembler file instead of this `O0` function attribute?