### PR TITLE
Move bootloader and fastflash code to load_vector_table function

### DIFF
--- a/bootloader/bootloader.c
+++ b/bootloader/bootloader.c
@@ -78,18 +78,7 @@ void show_unofficial_warning(const uint8_t *hash)
 
 void __attribute__((noreturn)) load_app(void)
 {
-	// Relocate vector tables
-	SCB_VTOR = FLASH_APP_START; // & 0xFFFF;
-
-	// Set stack pointer
-	__asm__ volatile("msr msp, %0"::"g" (*(volatile uint32_t *)FLASH_APP_START));
-
-	// Jump to address
-	(*(void (**)())(FLASH_APP_START + 4))();
-
-	// forever loop to indicate to the compiler that this function does not return.
-	// this avoids the stack protector injecting code that faults with the new stack.
-	for (;;);
+	load_vector_table((const vector_table_t *) FLASH_APP_START);
 }
 
 bool firmware_present(void)

--- a/timer.c
+++ b/timer.c
@@ -22,6 +22,7 @@
 
 #include <libopencm3/stm32/rcc.h>
 #include <libopencm3/cm3/systick.h>
+#include <libopencm3/cm3/vector.h>
 
 /* 1 tick = 1 ms */
 volatile uint32_t system_millis;

--- a/timer.h
+++ b/timer.h
@@ -17,6 +17,8 @@
  * along with this library.  If not, see <http://www.gnu.org/licenses/>.
  */
 
+#ifndef __TIMER_H__
+#define __TIMER_H__
 
 #include <stdint.h>
 
@@ -28,4 +30,4 @@ extern uint32_t system_millis_lock_start;
 
 void timer_init(void);
 
-void sys_tick_handler(void);
+#endif


### PR DESCRIPTION
Removes duplicate code and uses a more idomatic method of loading the vector table.