### PR TITLE
Add Fujicoin

### DIFF
--- a/firmware/coins.c
+++ b/firmware/coins.c
@@ -34,6 +34,7 @@ const CoinType coins[COINS_COUNT] = {
 	{true, "Dash",          true, " DASH", true,   76, true,     100000, true,   16, true, "\x19" "DarkCoin Signed Message:\n", true, 0x02fe52cc, true, 0x02fe52f8, true, false, },
 	{true, "Zcash",         true, " ZEC",  true, 7352, true,    1000000, true, 7357, true, "\x16" "Zcash Signed Message:\n",    true, 0x0488b21e, true, 0x0488ade4, true, false, },
 	{true, "Zcash Testnet", true, " TAZ",  true, 7461, true,   10000000, true, 7354, true, "\x16" "Zcash Signed Message:\n",    true, 0x043587cf, true, 0x04358394, true, false, },
+        {true, "FujiCoin",      true, " FJC",  true,   36, true,   50000000, true,   16, true, "\x19" "FujiCoin Signed Message:\n", true, 0x0488b21e, true, 0x0488ade4, true, true, },        
 };
 
 const CoinType *coinByName(const char *name)


### PR DESCRIPTION
Hi prusnak,

Please add Fujicoin.

We are now developing electrum-FJC.
The electrum-FJC for test can be obtained here.
https://bitcointalk.org/index.php?topic=644601.msg20043948#msg20043948

Website: http://www.fujicoin.org/
Explorer: http://explorer.fujicoin.org/
electrum-FJC: https://github.com/fujicoin/electrum-fjc

Thanks,
motty
