### PR TITLE
Fixed array sizes again.

### DIFF
--- a/firmware/transaction.c
+++ b/firmware/transaction.c
@@ -64,8 +64,8 @@ bool compute_address(const CoinType *coin,
 					 bool has_multisig, const MultisigRedeemScriptType *multisig,
 					 char address[MAX_ADDR_SIZE]) {
 
-	uint8_t raw[34];
-	uint8_t digest[MAX_ADDR_RAW_SIZE];
+	uint8_t raw[MAX_ADDR_RAW_SIZE];
+	uint8_t digest[32];
 	size_t prelen;
 
 	if (has_multisig) {


### PR DESCRIPTION
This is the correct fix for 09917920ba313da4dcdc7c64d47b014440bf822d
(how the code was meant to be written).