### PR TITLE
fix hangs due to using stale rng status

### DIFF
--- a/Makefile.include
+++ b/Makefile.include
@@ -65,6 +65,12 @@ else
 CFLAGS += -DMEMORY_PROTECT=1
 endif
 
+ifeq ($(DEBUG_RNG), 1)
+CFLAGS += -DDEBUG_RNG=1
+else
+CFLAGS += -DDEBUG_RNG=0
+endif
+
 LDFLAGS  += --static \
             -Wl,--start-group \
             -lc \

--- a/firmware/fsm.c
+++ b/firmware/fsm.c
@@ -330,12 +330,14 @@ void fsm_msgWipeDevice(WipeDevice *msg)
 
 void fsm_msgGetEntropy(GetEntropy *msg)
 {
+#if !DEBUG_RNG
 	layoutDialogSwipe(&bmp_icon_question, _("Cancel"), _("Confirm"), NULL, _("Do you really want to"), _("send entropy?"), NULL, NULL, NULL, NULL);
 	if (!protectButton(ButtonRequestType_ButtonRequest_ProtectCall, false)) {
 		fsm_sendFailure(FailureType_Failure_ActionCancelled, NULL);
 		layoutHome();
 		return;
 	}
+#endif
 	RESP_INIT(Entropy);
 	uint32_t len = msg->size;
 	if (len > 1024) {

--- a/rng.c
+++ b/rng.c
@@ -27,7 +27,7 @@ uint32_t random32(void)
 {
 	static uint32_t last = 0, new = 0;
 	while (new == last) {
-		if (((RNG_SR & (RNG_SR_SEIS | RNG_SR_CEIS)) == 0) && ((RNG_SR & RNG_SR_DRDY) > 0)) {
+		if ((RNG_SR & (RNG_SR_SECS | RNG_SR_CECS | RNG_SR_DRDY)) == RNG_SR_DRDY) {
 			new = RNG_DR;
 		}
 	}

--- a/setup.c
+++ b/setup.c
@@ -42,7 +42,7 @@ void setup(void)
 
 	// enable RNG
 	rcc_periph_clock_enable(RCC_RNG);
-	RNG_CR |= RNG_CR_IE | RNG_CR_RNGEN;
+	RNG_CR |= RNG_CR_RNGEN;
 	// to be extra careful and heed the STM32F205xx Reference manual, Section 20.3.1
 	// we don't use the first random number generated after setting the RNGEN bit in setup
 	random32();
@@ -73,6 +73,9 @@ void setup(void)
 
 void setupApp(void)
 {
+	// for completeness, disable RNG peripheral interrupts for old bootloaders that had
+	// enabled them in RNG control register (the RNG interrupt was never enabled in the NVIC)
+	RNG_CR &= ~RNG_CR_IE;
 	// the static variables in random32 are separate between the bootloader and firmware.
 	// therefore, they need to be initialized here so that we can be sure to avoid dupes.
 	// this is to try to comply with STM32F205xx Reference manual - Section 20.3.1:


### PR DESCRIPTION
**High level info:**
This PR fixes hangs that are a result of how function `random32` mis-interprets (stale) RNG peripheral status.

Reference #153. This is the same fundamental problem. I closed #153  last time because it didn't seem to have momentum for getting merged. This time, I actually have experienced the hangs, can reproduce them, and have runtime gdb backtrace and register proof.

These device hangs can manifest themselves during signing messages, displaying number pads, resetting the device, switching between coins in the web wallet GUI, or simply booting up. I've experienced all of the aforementioned issues and tracked them to this single root cause.

**About the changes:**
1) first, this change does not set the interrupt enable bit in the rng control register. currently, the interrupt is not handled -- no need to set the bit.
2) second, DEBUG_RNG defaults to off since it's only a testing switch. Right now, the switch just makes it easier to quickly pull a bunch of entropy for quality testing.
3) **lastly, the bulk of the changes**: this change checks the SECS and CECS bits in the rng status register directly, rather than indirectly via SEIS and CEIS.
the way it appears to work is that, SECS and SEIS, and CECS and CEIS, match when an error is first detected.
but, SEIS and CEIS do not stay synched with the clock and fault detector as SECS and CECS do.
so, when an error occurs SEIS and CEIS go high and stay high because our code never resets them.
it appears to be the case that an error passes and SECS and CECS then go low again. that's why it's better to check them instead.
Excerpt from the reference manual section (20.4.2) on the RNG status register (RNG_SR):
```
Bit 2 SECS: Seed error current status
0: No faulty sequence has currently been detected. If the SEIS bit is set, this means that a faulty sequence was detected and the situation has been recovered.
1: One of the following faulty sequences has been detected:
   More than 64 consecutive bits at the same value (0 or 1)
   More than 32 consecutive alternances of 0 and 1 (0101010101...01)

Bit 1 CECS: Clock error current status
0: The RNG_CLK clock has been correctly detected. If the CEIS bit is set, this means that a clock error was detected and the situation has been recovered
1: The RNG_CLK was not correctly detected (f RNG_CLK < f HCLK /16).

Bit 0 DRDY: Data ready
0: The RNG_DR register is not yet valid, no random data is available
1: The RNG_DR register contains valid random data
```

**Debug environment and GDB info:**
The debugging environment for this was done according to the dev kit at: https://mcudev.github.io/trezor-dev-kit/index.html

Example GDB backtrace and register info captured during a "hang" while performing a device reset (r3 contains the RNG_SR value -- 0x41 -- meaning that "a faulty sequence was detected and the situation has been recovered" -- but the code hangs there anyways) The code gets stuck executing lines 0x8043264 - 0x804326a:
![image](https://user-images.githubusercontent.com/6440430/28321095-4f39eac4-6ba0-11e7-8e2d-c7bc3c3252a4.png)


Here's another full backtrace taken while the hang was experienced during a message signing operation:
```
#0  random32 () at rng.c:30
#1  0x080213dc in generate_k_random (prime=0x80480c0 <secp256k1>, k=0x2001fd18) at ../vendor/trezor-crypto/ecdsa.c:201
#2  curve_to_jacobian (p=0x80481e4 <secp256k1+292>, jp=jp@entry=0x2001fcd0, prime=prime@entry=0x80480c0 <secp256k1>)
    at ../vendor/trezor-crypto/ecdsa.c:210
#3  0x08021f86 in scalar_multiply (curve=curve@entry=0x80480c0 <secp256k1>, k=k@entry=0x2001fd68, res=res@entry=0x2001fd8c)
    at ../vendor/trezor-crypto/ecdsa.c:607
#4  0x0802273c in ecdsa_get_public_key33 (curve=0x80480c0 <secp256k1>,
    priv_key=priv_key@entry=0x2000efa0 <node+40> "\224\065S\257\033\016\035T\205KH\221,f\356\366\227\063$\360}\026a]\342\324\316|\033\061\020m",
    pub_key=pub_key@entry=0x2000efc0 <node+72> "") at ../vendor/trezor-crypto/ecdsa.c:842
#5  0x080335c8 in hdnode_fill_public_key (node=0x2000ef78 <node>) at ../vendor/trezor-crypto/bip32.c:412
#6  hdnode_private_ckd (inout=inout@entry=0x2000ef78 <node>, i=0) at ../vendor/trezor-crypto/bip32.c:182
#7  0x08033882 in hdnode_private_ckd_cached (inout=inout@entry=0x2000ef78 <node>, i=i@entry=0x20002898 <msg_data+4>, i_count=i_count@entry=5,
    fingerprint=fingerprint@entry=0x0) at ../vendor/trezor-crypto/bip32.c:375
#8  0x08015944 in fsm_getDerivedNode (address_n_count=5, address_n=0x20002898 <msg_data+4>, curve=<optimized out>) at fsm.c:189
#9  fsm_msgSignMessage (msg=0x20002894 <msg_data>) at fsm.c:792
#10 0x08011b40 in MessageProcessFunc (ptr=<optimized out>, msg_id=<optimized out>, dir=<optimized out>, type=<optimized out>) at messages.c:64
#11 msg_process (msg_size=<optimized out>, msg_raw=0x20005894 <msg_in> "\b\254\200\200\200\b\b\200\200\200\200\b\b\200\200\200\200\b\b",
    fields=0x806ce50 <SignMessage_fields>, msg_id=38, type=110 'n') at messages.c:232
#12 msg_read_common (type=<optimized out>, buf=<optimized out>, len=<optimized out>) at messages.c:281
#13 0x0804456a in stm32fx07_poll (usbd_dev=0x20013f70 <usbd_dev>) at ../../usb/usb_fx07_common.c:348
#14 0x08010376 in usbPoll () at usb.c:414
#15 0x08012ea6 in main () at trezor.c:127
#16 0x080440f0 in reset_handler () at ../../cm3/vector.c:94
```