### PR TITLE
Travis CI Submodules In Pull Requests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,12 @@ sudo: false
 dist: trusty
 language: c
 
+git:
+  submodules: false
+
+before_install:
+  - vendor/travis-submodules
+
 addons:
   apt:
     packages:

--- a/vendor/travis-submodules
+++ b/vendor/travis-submodules
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+set -e
+
+if [ "$TRAVIS_PULL_REQUEST" = "false" ]; then
+    git submodule update --init --recursive
+else
+    GH_USER="${TRAVIS_PULL_REQUEST_SLUG%/*}"
+
+    git submodule init
+
+    git submodule--helper list | while read -r mode sha1 stage sm_path
+    do
+        if ! git submodule update --recursive "$sm_path"; then
+            name="$(git submodule--helper name "$sm_path")"
+
+            git config --file .gitmodules submodule."$name".url "https://github.com/$GH_USER/$name.git"
+
+            git submodule sync "$sm_path"
+            git submodule update --recursive "$sm_path"
+        fi
+    done
+fi


### PR DESCRIPTION
When submodules are updated in pull requests, Travis CI will fail to build. This script rewrites the URL to the fork of the submodule.

The script can be seen in action at https://travis-ci.org/trezor/trezor-mcu/builds/258655450

Alternatively, we could switch to something sane like `git subtree`. Thoughts?