### PR TITLE
Assert that Features.coins max_count is large enough

### DIFF
--- a/firmware/coins.h
+++ b/firmware/coins.h
@@ -20,6 +20,7 @@
 #ifndef __COINS_H__
 #define __COINS_H__
 
+#include "messages.pb.h"
 #include "types.pb.h"
 
 #if DEBUG_LINK
@@ -27,6 +28,8 @@
 #else
 #define COINS_COUNT 8
 #endif
+
+_Static_assert(pb_arraysize(Features, coins) >= COINS_COUNT, "Features.coins max_count not large enough");
 
 extern const CoinType coins[COINS_COUNT];
 

--- a/firmware/protob/messages.options
+++ b/firmware/protob/messages.options
@@ -2,7 +2,7 @@ Features.vendor				max_size:33
 Features.device_id			max_size:25
 Features.language			max_size:17
 Features.label				max_size:33
-Features.coins				max_count:9
+Features.coins				max_count:10
 Features.revision			max_size:20
 Features.bootloader_hash		max_size:32
 

--- a/firmware/protob/messages.pb.h
+++ b/firmware/protob/messages.pb.h
@@ -506,7 +506,7 @@ typedef struct _Features {
     bool has_label;
     char label[33];
     size_t coins_count;
-    CoinType coins[9];
+    CoinType coins[10];
     bool has_initialized;
     bool initialized;
     bool has_revision;
@@ -803,7 +803,7 @@ extern const uint32_t SignTx_lock_time_default;
 /* Initializer values for message structs */
 #define Initialize_init_default                  {0}
 #define GetFeatures_init_default                 {0}
-#define Features_init_default                    {false, "", false, 0, false, 0, false, 0, false, 0, false, "", false, 0, false, 0, false, "", false, "", 0, {CoinType_init_default, CoinType_init_default, CoinType_init_default, CoinType_init_default, CoinType_init_default, CoinType_init_default, CoinType_init_default, CoinType_init_default, CoinType_init_default}, false, 0, false, {0, {0}}, false, {0, {0}}, false, 0, false, 0, false, 0, false, 0, false, 0, false, 0}
+#define Features_init_default                    {false, "", false, 0, false, 0, false, 0, false, 0, false, "", false, 0, false, 0, false, "", false, "", 0, {CoinType_init_default, CoinType_init_default, CoinType_init_default, CoinType_init_default, CoinType_init_default, CoinType_init_default, CoinType_init_default, CoinType_init_default, CoinType_init_default, CoinType_init_default}, false, 0, false, {0, {0}}, false, {0, {0}}, false, 0, false, 0, false, 0, false, 0, false, 0, false, 0}
 #define ClearSession_init_default                {0}
 #define ApplySettings_init_default               {false, "", false, "", false, 0, false, {0, {0}}}
 #define ApplyFlags_init_default                  {false, 0}
@@ -865,7 +865,7 @@ extern const uint32_t SignTx_lock_time_default;
 #define DebugLinkFlashErase_init_default         {false, 0}
 #define Initialize_init_zero                     {0}
 #define GetFeatures_init_zero                    {0}
-#define Features_init_zero                       {false, "", false, 0, false, 0, false, 0, false, 0, false, "", false, 0, false, 0, false, "", false, "", 0, {CoinType_init_zero, CoinType_init_zero, CoinType_init_zero, CoinType_init_zero, CoinType_init_zero, CoinType_init_zero, CoinType_init_zero, CoinType_init_zero, CoinType_init_zero}, false, 0, false, {0, {0}}, false, {0, {0}}, false, 0, false, 0, false, 0, false, 0, false, 0, false, 0}
+#define Features_init_zero                       {false, "", false, 0, false, 0, false, 0, false, 0, false, "", false, 0, false, 0, false, "", false, "", 0, {CoinType_init_zero, CoinType_init_zero, CoinType_init_zero, CoinType_init_zero, CoinType_init_zero, CoinType_init_zero, CoinType_init_zero, CoinType_init_zero, CoinType_init_zero, CoinType_init_zero}, false, 0, false, {0, {0}}, false, {0, {0}}, false, 0, false, 0, false, 0, false, 0, false, 0, false, 0}
 #define ClearSession_init_zero                   {0}
 #define ApplySettings_init_zero                  {false, "", false, "", false, 0, false, {0, {0}}}
 #define ApplyFlags_init_zero                     {false, 0}
@@ -1159,7 +1159,7 @@ extern const pb_field_t DebugLinkFlashErase_fields[2];
 /* Maximum encoded size of messages (where known) */
 #define Initialize_size                          0
 #define GetFeatures_size                         0
-#define Features_size                            (273 + 9*CoinType_size)
+#define Features_size                            (279 + 10*CoinType_size)
 #define ClearSession_size                        0
 #define ApplySettings_size                       1083
 #define ApplyFlags_size                          6


### PR DESCRIPTION
Prevents silent crash in `fsm_msgGetFeatures` if `Features.coins` `max_count` is not large enough. Feel free to change the `_Static_assert` message.

/cc @jhoenicke 