### PR TITLE
Test matrix of DEBUG_LINK and FASTFLASH

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,19 +5,26 @@ language: c
 addons:
   apt:
     packages:
-    - build-essential
-    - git
-    - gcc-arm-none-eabi
-    - libnewlib-arm-none-eabi
+      - build-essential
+      - gcc-arm-none-eabi
+      - libnewlib-arm-none-eabi
+
+env:
+  global:
+    - MAKEFLAGS=-j2
+  matrix:
+    - DEBUG_LINK=0 FASTFLASH=0
+    - DEBUG_LINK=1 FASTFLASH=0
+    - DEBUG_LINK=0 FASTFLASH=1
+    - DEBUG_LINK=1 FASTFLASH=1
 
 script:
-  - CFLAGS="-std=c99" make -C vendor/libopencm3
+  - CFLAGS="-std=c99" make -C vendor/libopencm3 lib/stm32/f2
   - make
   - make -C bootloader
   - make -C fastflash
   - make -C firmware
   - make -C demo
-  - make -C firmware clean && make -C firmware FASTFLASH=1
 
 notifications:
   webhooks:

--- a/firmware/Makefile
+++ b/firmware/Makefile
@@ -72,11 +72,14 @@ else
 CFLAGS += -DFASTFLASH=0
 endif
 
+DEBUG_LINK ?= 0
+DEBUG_LOG  ?= 0
+
 CFLAGS += -Wno-sequence-point
 CFLAGS += -Iprotob -DPB_FIELD_16BIT=1
 CFLAGS += -DQR_MAX_VERSION=0
-CFLAGS += -DDEBUG_LINK=0
-CFLAGS += -DDEBUG_LOG=0
+CFLAGS += -DDEBUG_LINK=$(DEBUG_LINK)
+CFLAGS += -DDEBUG_LOG=$(DEBUG_LOG)
 CFLAGS += -DSCM_REVISION='"$(shell git rev-parse HEAD | sed 's:\(..\):\\x\1:g')"'
 CFLAGS += -DUSE_ETHEREUM=1
 


### PR DESCRIPTION
This should catch inconsistencies with `Features.coins` or if there is a
build configuration that makes the firmware too large.

Also, add `MAKEFLAGS` and only build `STM32F2` support in `libopencm3` to
speed up build time