### PR TITLE
Improve old_storage_size logic

### DIFF
--- a/firmware/storage.c
+++ b/firmware/storage.c
@@ -148,16 +148,14 @@ bool storage_from_flash(void)
 	// copy storage
 	size_t old_storage_size = 0;
 
-	if (version == 1 || version == 2) {
+	if (version == 0) {
+	} else if (version <= 2) {
 		old_storage_size = OLD_STORAGE_SIZE(imported);
-	} else
-	if (version == 3 || version == 4 || version == 5) {
+	} else if (version <= 5) {
 		old_storage_size = OLD_STORAGE_SIZE(homescreen);
-	} else
-	if (version == 6 || version == 7) {
+	} else if (version <= 7) {
 		old_storage_size = OLD_STORAGE_SIZE(u2f_counter);
-	} else
-	if (version == 8) {
+	} else if (version <= 8) {
 		old_storage_size = OLD_STORAGE_SIZE(flags);
 	}
 

--- a/firmware/storage.c
+++ b/firmware/storage.c
@@ -143,20 +143,22 @@ bool storage_from_flash(void)
 	memcpy(storage_uuid, (void *)(FLASH_STORAGE_START + 4), sizeof(storage_uuid));
 	data2hex(storage_uuid, sizeof(storage_uuid), storage_uuid_str);
 
+#define OLD_STORAGE_SIZE(last_member) (offsetof(Storage, last_member) + pb_membersize(Storage, last_member))
+
 	// copy storage
 	size_t old_storage_size = 0;
 
 	if (version == 1 || version == 2) {
-		old_storage_size = 460;
+		old_storage_size = OLD_STORAGE_SIZE(imported);
 	} else
 	if (version == 3 || version == 4 || version == 5) {
-		old_storage_size = 1488;
+		old_storage_size = OLD_STORAGE_SIZE(homescreen);
 	} else
 	if (version == 6 || version == 7) {
-		old_storage_size = 1496;
+		old_storage_size = OLD_STORAGE_SIZE(u2f_counter);
 	} else
 	if (version == 8) {
-		old_storage_size = 1504;
+		old_storage_size = OLD_STORAGE_SIZE(flags);
 	}
 
 	memset(&storage, 0, sizeof(Storage));


### PR DESCRIPTION
* Do not use hardcoded constants
* Do not include end padding
* More compact `if` statement (with `<=` instead of lots of `==`)