### PR TITLE
cleanup build, update libopencm3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,7 +19,7 @@ env:
     - DEBUG_LINK=1 FASTFLASH=1
 
 script:
-  - CFLAGS="-std=c99" make -C vendor/libopencm3 lib/stm32/f2
+  - make -C vendor/libopencm3 lib/stm32/f2
   - make
   - make -C bootloader
   - make -C fastflash

--- a/build-bootloader.sh
+++ b/build-bootloader.sh
@@ -12,9 +12,8 @@ docker run -t -v $(pwd)/build:/build:z $IMAGE /bin/sh -c "\
 	cd trezor-mcu && \
 	git checkout $TAG && \
 	git submodule update --init && \
-	CFLAGS='-std=c99' make -C vendor/libopencm3 && \
+	make -C vendor/libopencm3 && \
 	make && \
-	make -C bootloader && \
 	make -C bootloader align && \
 	cp bootloader/bootloader.bin /$BINFILE && \
 	cp bootloader/bootloader.elf /$ELFFILE"

--- a/build-firmware.sh
+++ b/build-firmware.sh
@@ -12,9 +12,8 @@ docker run -t -v $(pwd)/build:/build:z $IMAGE /bin/sh -c "\
 	cd trezor-mcu && \
 	git checkout $TAG && \
 	git submodule update --init && \
-	CFLAGS='-std=c99' make -C vendor/libopencm3 && \
+	make -C vendor/libopencm3 && \
 	make && \
-	make -C firmware && \
 	make -C firmware sign && \
 	cp firmware/trezor.bin /$BINFILE && \
 	cp firmware/trezor.elf /$ELFFILE"


### PR DESCRIPTION
Cleanup the build output:

```
In file included from ../cm3/../dispatch/vector_chipset.c:14:0,
                 from ../cm3/vector.c:25:
../cm3/../dispatch/../vf6xx/vector_chipset.c: In function 'pre_main':
../cm3/../dispatch/../vf6xx/vector_chipset.c:30:2: warning: implicit declaration of function 'asm' [-Wimplicit-function-declaration]
  asm ( \
  ^~~
```

This is fixed by:
https://github.com/libopencm3/libopencm3/commit/f3df01f14e90849caa821ccda8ade6c953085964

Also, libopencm3 has gone to c99:
https://github.com/libopencm3/libopencm3/commit/b86031978553ca3d6dd1eb9015c2d5ea4cdd8794

`git submodule update --remote vendor/libopencm3/`

updates from `b76d853a723d39bbc083495bb7460cf3f071476c` to `b0e050d10d12c42be031c34822117cfd3c5a0ea7`

`git diff b76d853a723d39bbc083495bb7460cf3f071476c b0e050d10d12c42be031c34822117cfd3c5a0ea7`

As a result, the build process can be cleaned up and simplified too.