### PR TITLE
memory_protect: add flash interface register check

### DIFF
--- a/memory.c
+++ b/memory.c
@@ -30,8 +30,8 @@ void memory_protect(void)
 #if MEMORY_PROTECT
 	// Reference STM32F205 Flash programming manual revision 5 http://www.st.com/resource/en/programming_manual/cd00233952.pdf
 	// Section 2.6 Option bytes
-	//                     set RDP level 2                   WRP for sectors 0 and 1
-	if ((((*OPTION_BYTES_1) & 0xFFEC) == 0xCCEC) && (((*OPTION_BYTES_2) & 0xFFF) == 0xFFC)) {
+	//                     set RDP level 2                   WRP for sectors 0 and 1      flash option control register matches
+	if ((((*OPTION_BYTES_1) & 0xFFEC) == 0xCCEC) && (((*OPTION_BYTES_2) & 0xFFF) == 0xFFC) && (FLASH_OPTCR == 0x0FFCCCED)) {
 		return; // already set up correctly - bail out
 	}
 	flash_unlock_option_bytes();


### PR DESCRIPTION
I don't think this is urgent. This is more to be complete with the recommendations of some newly published research: https://www.usenix.org/system/files/conference/woot17/woot17-paper-obermaier.pdf

Section 3.2.4 on countermeasures: "This includes the “read protection level status” in the FLASH OBR register as well as the option bytes themselves."

FLASH_OPTCR is the f2 family equivalent flash interface register.

I was thinking of masking off the two low bits in my comparison, but then decided to go with the simple equality test because the option lock seems like it should always be set, and we should not be in the midst of an update to the option bytes, when making this check.