### PR TITLE
Generate the protobuf files at build time

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -10,3 +10,6 @@
 [submodule "libopencm3"]
 	path = vendor/libopencm3
 	url = https://github.com/libopencm3/libopencm3.git
+[submodule "vendor/nanopb"]
+	path = vendor/nanopb
+	url = https://github.com/nanopb/nanopb.git

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,4 +8,5 @@ RUN apt-get update
 
 # install build tools and dependencies
 
-RUN apt-get install -y build-essential git python python-ecdsa gcc-arm-none-eabi
+RUN apt-get install -y build-essential git python python-ecdsa gcc-arm-none-eabi protobuf-compiler \
+	libprotobuf-dev python-protobuf python3-protobuf

--- a/build-firmware.sh
+++ b/build-firmware.sh
@@ -13,6 +13,8 @@ docker run -t -v $(pwd)/build:/build:z $IMAGE /bin/sh -c "\
 	git checkout $TAG && \
 	git submodule update --init && \
 	make -C vendor/libopencm3 && \
+	make -C vendor/nanopb/generator/proto && \
+	make -C firmware/protob && \
 	make && \
 	make -C firmware sign && \
 	cp firmware/trezor.bin /$BINFILE && \

--- a/firmware/protob/Makefile
+++ b/firmware/protob/Makefile
@@ -1,7 +1,7 @@
 all: messages.pb.c storage.pb.c types.pb.c messages_map.h
 
 %.pb.c: %.pb %.options
-	nanopb_generator.py $< -L '#include "%s"' -T
+	../../vendor/nanopb/generator/nanopb_generator.py $< -L '#include "%s"' -T
 
 %.pb: %.proto
 	protoc -I/usr/include -I. $< -o $@


### PR DESCRIPTION
This is so as to improve the build reliability by ensuring protobuf files are generated at build time, to make life easier for future maintainers, and reduce ceremony of generating files and checking them in.

I've not been so opinionated as to remove the generated files from the repo as they get clobbered during the generation, but I do actually think it's a reasonable idea because it's very unambiguous that the developer should not hand-maintain them - if you comment on the PR that you would like this, I can add it to the change set.

Some notes: 

- I've pinned the nanopb submodule to the version that originally generated the files (0.2.9.3).
- In testing, I can confirm the files generated are identical down to the byte, to those presently in the repo.

I'd like to automate the generation of the coins files also in a future PR just as a tidy up, as I see some cut and manual generating and pasting of generated results occurring there also.  