### PR TITLE
Generate coins.h and coins.c source code at build time

### DIFF
--- a/Makefile.include
+++ b/Makefile.include
@@ -139,7 +139,7 @@ $(NAME).elf: $(OBJS) $(LDSCRIPT) $(TOOLCHAIN_DIR)/lib/libopencm3_stm32f2.a $(TOP
 %.small.o: %.c Makefile
 	$(CC) $(CFLAGS) -MMD -o $@ -c $<
 
-clean:
+clean::
 	rm -f $(OBJS)
 	rm -f *.a
 	rm -f *.bin

--- a/firmware/.gitignore
+++ b/firmware/.gitignore
@@ -1,0 +1,2 @@
+coins_array.h
+coins_count.h

--- a/firmware/Makefile
+++ b/firmware/Makefile
@@ -95,3 +95,18 @@ bootloader.o: ../fastflash/bootloader.bin
 		--redefine-sym _binary_$(shell echo -n "$<" | tr -c "[:alnum:]" "_")_size=__bootloader_size__ \
 		--rename-section .data=.rodata \
 		$< $@
+
+# ensure header files are generated prior to compiling sources
+coins.c crypto.c fsm.c transaction.c: coins_count.h
+coins.c: coins_array.h
+
+#################
+# Code Generation
+coins_count.h: coins-gen.py coins.json
+	./$< count > $@
+
+coins_array.h: coins-gen.py coins.json
+	./$< array > $@
+
+clean::
+	rm -f coins_count.h coins_array.h

--- a/firmware/coins-gen.py
+++ b/firmware/coins-gen.py
@@ -1,9 +1,14 @@
-#!/usr/bin/env python3
-import json
+#!/usr/bin/env python2
+from __future__ import print_function
+import json, sys
 
-coins_json = json.load(open('../vendor/trezor-common/coins.json', 'r'))
+coins_json = json.load(open('coins.json', 'r'))
 
 coins_stable, coins_debug = [], []
+
+if len(sys.argv) != 2 or sys.argv[1] not in ("count", "array"):
+    print("usage: coins-gen.py [count|array]\n", file=sys.stderr)
+    sys.exit(1)
 
 
 def get_fields(coin):
@@ -59,20 +64,23 @@ for coin in coins_json:
 justify_width(coins_stable)
 justify_width(coins_debug)
 
-for row in coins_stable:
-    print('\t{' + ' '.join(row) + ' },')
+print("// THIS IS A GENERATED FILE - DO NOT HAND EDIT\n\n")
 
-print('#if DEBUG_LINK')
+if sys.argv[1] == "array":
+    for row in coins_stable:
+        print('\t{' + ' '.join(row) + ' },')
 
-for row in coins_debug:
-    print('\t{' + ' '.join(row) + ' },')
+    print('#if DEBUG_LINK')
 
-print('#endif')
+    for row in coins_debug:
+        print('\t{' + ' '.join(row) + ' },')
 
-print('-' * 32)
+    print('#endif')
 
-print('#if DEBUG_LINK')
-print('#define COINS_COUNT %d' % (len(coins_stable) + len(coins_debug)))
-print('#else')
-print('#define COINS_COUNT %d' % (len(coins_stable)))
-print('#endif')
+
+if sys.argv[1] == "count":
+    print('#if DEBUG_LINK')
+    print('#define COINS_COUNT %d' % (len(coins_stable) + len(coins_debug)))
+    print('#else')
+    print('#define COINS_COUNT %d' % (len(coins_stable)))
+    print('#endif')

--- a/firmware/coins.c
+++ b/firmware/coins.c
@@ -26,18 +26,7 @@
 // filled CoinType Protobuf structure defined in https://github.com/trezor/trezor-common/blob/master/protob/types.proto#L133
 // address types > 0xFF represent a two-byte prefix in big-endian order
 const CoinType coins[COINS_COUNT] = {
-	{true, "Bitcoin",  true, " BTC",  true,    0, true,     500000, true,    5, true, "\x18" "Bitcoin Signed Message:\n",  true, 0x0488b21e, true, 0x0488ade4, true, true,  false, 0, },
-	{true, "Testnet",  true, " TEST", true,  111, true,   10000000, true,  196, true, "\x18" "Bitcoin Signed Message:\n",  true, 0x043587cf, true, 0x04358394, true, true,  false, 0, },
-	{true, "Bcash",    true, " BCH",  true,    0, true,     500000, true,    5, true, "\x18" "Bitcoin Signed Message:\n",  true, 0x0488b21e, true, 0x0488ade4, true, false, true,  0, },
-	{true, "Namecoin", true, " NMC",  true,   52, true,   10000000, true,    5, true, "\x19" "Namecoin Signed Message:\n", true, 0x019da462, true, 0x019d9cfe, true, false, false, 0, },
-	{true, "Litecoin", true, " LTC",  true,   48, true,   40000000, true,   50, true, "\x19" "Litecoin Signed Message:\n", true, 0x019da462, true, 0x019d9cfe, true, true,  false, 0, },
-	{true, "Dogecoin", true, " DOGE", true,   30, true, 1000000000, true,   22, true, "\x19" "Dogecoin Signed Message:\n", true, 0x02facafd, true, 0x02fac398, true, false, false, 0, },
-	{true, "Dash",     true, " DASH", true,   76, true,     100000, true,   16, true, "\x19" "DarkCoin Signed Message:\n", true, 0x02fe52cc, true, 0x02fe52f8, true, false, false, 0, },
-	{true, "Zcash",    true, " ZEC",  true, 7352, true,    1000000, true, 7357, true, "\x16" "Zcash Signed Message:\n",    true, 0x0488b21e, true, 0x0488ade4, true, false, false, 0, },
-#if DEBUG_LINK
-	{true, "Bcash Testnet", true, " TBCH", true,  111, true, 10000000, true,  196, true, "\x18" "Bitcoin Signed Message:\n", true, 0x043587cf, true, 0x04358394, true, false, true,  0, },
-	{true, "Zcash Testnet", true, " TAZ",  true, 7461, true, 10000000, true, 7354, true, "\x16" "Zcash Signed Message:\n",   true, 0x043587cf, true, 0x04358394, true, false, false, 0, },
-#endif
+#include "coins_array.h"
 };
 
 const CoinType *coinByName(const char *name)

--- a/firmware/coins.h
+++ b/firmware/coins.h
@@ -21,13 +21,8 @@
 #define __COINS_H__
 
 #include "messages.pb.h"
-#include "types.pb.h"
 
-#if DEBUG_LINK
-#define COINS_COUNT 10
-#else
-#define COINS_COUNT 8
-#endif
+#include "coins_count.h"
 
 _Static_assert(pb_arraysize(Features, coins) >= COINS_COUNT, "Features.coins max_count not large enough");
 

--- a/firmware/coins.json
+++ b/firmware/coins.json
@@ -1,0 +1,1 @@
+../vendor/trezor-common/coins.json

--- a/firmware/protob/Makefile
+++ b/firmware/protob/Makefile
@@ -13,4 +13,4 @@ messages_map.h: messages_map.py messages_pb2.py types_pb2.py
 	./$< > $@
 
 clean:
-	rm -f *.pb *.o *.pb.c *.pb.h *_pb2.py messages_map.h
+	rm -f *.pb *.o *.d *.pb.c *.pb.h *_pb2.py messages_map.h


### PR DESCRIPTION
This generates the coins.h and coins.c files from coins.json source at build time, to help ensure consistency.

Previously it was reliant upon the user to run coins-gen.py manually and hand-edit the coins.h and coins.c files.

I'm checking the two new generated files in here `coins_array.h` and `coins_count.h`, however that is just for illustration - the build process clobbers them consistently.
