### PR TITLE
Makefile.include: Generate dependency files before build

### DIFF
--- a/Makefile.include
+++ b/Makefile.include
@@ -134,10 +134,13 @@ $(NAME).elf: $(OBJS) $(LDSCRIPT) $(TOOLCHAIN_DIR)/lib/libopencm3_stm32f2.a $(TOP
 	$(AS) $(CPUFLAGS) -o $@ $<
 
 %.o: %.c Makefile
-	$(CC) $(CFLAGS) -MMD -o $@ -c $<
+	$(CC) $(CFLAGS) -MMD -MP -o $@ -c $<
 
 %.small.o: %.c Makefile
-	$(CC) $(CFLAGS) -MMD -o $@ -c $<
+	$(CC) $(CFLAGS) -MMD -MP -o $@ -c $<
+
+%.d: %.c Makefile
+	@$(CC) $(CFLAGS) -MM -MP -MG -o $@ $<
 
 clean::
 	rm -f $(OBJS)

--- a/Makefile.include
+++ b/Makefile.include
@@ -142,6 +142,9 @@ $(NAME).elf: $(OBJS) $(LDSCRIPT) $(TOOLCHAIN_DIR)/lib/libopencm3_stm32f2.a $(TOP
 %.d: %.c Makefile
 	@$(CC) $(CFLAGS) -MM -MP -MG -o $@ $<
 
+%.small.d: %.c Makefile
+	@$(CC) $(CFLAGS) -MM -MP -MG -o $@ $<
+
 clean::
 	rm -f $(OBJS)
 	rm -f *.a

--- a/firmware/Makefile
+++ b/firmware/Makefile
@@ -101,14 +101,6 @@ bootloader.o: ../fastflash/bootloader.bin
 		--rename-section .data=.rodata \
 		$< $@
 
-# ensure header files are generated prior to compiling sources
-coins.c crypto.c fsm.c transaction.c: coins_count.h
-coins.c: coins_array.h
-
-nem2.c layout2.c fsm.c: nem_mosaics.h
-
-#################
-# Code Generation
 coins_count.h: coins-gen.py coins.json
 	./$< count > $@
 


### PR DESCRIPTION
Generate dependency files before the build (so we do not have to specify generated header file dependencies manually)

 * `-MP` is used to generate empty rules for header files (so we don't have to remove stale `.d` files if a header file is deleted)
 * `-MG` is used to make GCC ignore missing header files (so we can create dependencies on generated header files such as `nem_mosaics.h`)