### PR TITLE
Enable SIGHASH_FORKID for SIGVERSION_BASE and SegWit

### DIFF
--- a/firmware/coins-gen.py
+++ b/firmware/coins-gen.py
@@ -21,6 +21,7 @@ def get_fields(coin):
         'true' if coin['address_type_p2sh'] is not None else 'false',
         'true' if coin['segwit'] else 'false',
         'true' if coin['forkid'] is not None else 'false',
+        'true' if coin['force_bip143'] else 'false',
         '%d' % coin['address_type'] if coin['address_type'] is not None else '0',
         '%d' % coin['address_type_p2sh'] if coin['address_type_p2sh'] is not None else '0',
         '0x%s' % coin['xpub_magic'] if coin['xpub_magic'] is not None else '0x00000000',

--- a/firmware/coins.h
+++ b/firmware/coins.h
@@ -34,6 +34,7 @@ typedef struct _CoinInfo {
 	bool has_address_type_p2sh;
 	bool has_segwit;
 	bool has_forkid;
+	bool force_bip143;
 	// address types > 0xFF represent a two-byte prefix in big-endian order
 	uint32_t address_type;
 	uint32_t address_type_p2sh;

--- a/firmware/fsm.c
+++ b/firmware/fsm.c
@@ -258,6 +258,8 @@ void fsm_msgGetFeatures(GetFeatures *msg)
 		resp->coins[i].segwit = coins[i].has_segwit;
 		resp->coins[i].has_forkid = coins[i].has_forkid;
 		resp->coins[i].forkid = coins[i].forkid;
+		resp->coins[i].has_force_bip143 = true;
+		resp->coins[i].force_bip143 = coins[i].force_bip143;
 	}
 	resp->has_initialized = true; resp->initialized = storage_isInitialized();
 	resp->has_imported = true; resp->imported = storage.has_imported && storage.imported;

--- a/firmware/protob/messages.options
+++ b/firmware/protob/messages.options
@@ -2,7 +2,7 @@ Features.vendor				max_size:33
 Features.device_id			max_size:25
 Features.language			max_size:17
 Features.label				max_size:33
-Features.coins				max_count:10
+Features.coins				max_count:11
 Features.revision			max_size:20
 Features.bootloader_hash		max_size:32
 

--- a/firmware/signing.c
+++ b/firmware/signing.c
@@ -733,6 +733,8 @@ static bool signing_sign_segwit_input(TxInputType *txinput) {
 		resp.has_serialized = true;
 		if (!signing_sign_hash(txinput, node.private_key, node.public_key, hash))
 			return false;
+
+		uint8_t sighash = signing_hash_type() & 0xff;
 		if (txinput->has_multisig) {
 			uint32_t r = 1; // skip number of items (filled in later)
 			resp.serialized.serialized_tx.bytes[r] = 0; r++;
@@ -742,7 +744,7 @@ static bool signing_sign_segwit_input(TxInputType *txinput) {
 					continue;
 				}
 				nwitnesses++;
-				txinput->multisig.signatures[i].bytes[txinput->multisig.signatures[i].size] = 1;
+				txinput->multisig.signatures[i].bytes[txinput->multisig.signatures[i].size] = sighash;
 				r += tx_serialize_script(txinput->multisig.signatures[i].size + 1, txinput->multisig.signatures[i].bytes, resp.serialized.serialized_tx.bytes + r);
 			}
 			uint32_t script_len = compile_script_multisig(&txinput->multisig, 0);
@@ -753,7 +755,7 @@ static bool signing_sign_segwit_input(TxInputType *txinput) {
 		} else { // single signature
 			uint32_t r = 0;
 			r += ser_length(2, resp.serialized.serialized_tx.bytes + r);
-			resp.serialized.signature.bytes[resp.serialized.signature.size] = 1;
+			resp.serialized.signature.bytes[resp.serialized.signature.size] = sighash;
 			r += tx_serialize_script(resp.serialized.signature.size + 1, resp.serialized.signature.bytes, resp.serialized.serialized_tx.bytes + r);
 			r += tx_serialize_script(33, node.public_key, resp.serialized.serialized_tx.bytes + r);
 			resp.serialized.serialized_tx.size = r;

--- a/firmware/signing.c
+++ b/firmware/signing.c
@@ -807,9 +807,9 @@ void signing_txack(TransactionType *tx)
 				}
 #endif
 
-				if (coin->has_forkid) {
+				if (coin->force_bip143) {
 					if (!tx->inputs[0].has_amount) {
-						fsm_sendFailure(FailureType_Failure_DataError, _("SIGHASH_FORKID input without amount"));
+						fsm_sendFailure(FailureType_Failure_DataError, _("BIP 143 input without amount"));
 						signing_abort();
 						return;
 					}
@@ -1027,7 +1027,7 @@ void signing_txack(TransactionType *tx)
 			resp.serialized.has_serialized_tx = true;
 			if (tx->inputs[0].script_type == InputScriptType_SPENDMULTISIG
 				|| tx->inputs[0].script_type == InputScriptType_SPENDADDRESS) {
-				if (!coin->has_forkid) {
+				if (!coin->force_bip143) {
 					fsm_sendFailure(FailureType_Failure_DataError, _("Transaction has changed during signing"));
 					signing_abort();
 					return;

--- a/firmware/signing.c
+++ b/firmware/signing.c
@@ -453,7 +453,7 @@ void signing_init(uint32_t _inputs_count, uint32_t _outputs_count, const CoinInf
 	multisig_fp_mismatch = false;
 	next_nonsegwit_input = 0xffffffff;
 
-	tx_init(&to, inputs_count, outputs_count, version, lock_time, 0, false);
+	tx_init(&to, inputs_count, outputs_count, version, lock_time, 0);
 	// segwit hashes for hashPrevouts and hashSequence
 	sha256_Init(&hashers[0]);
 	sha256_Init(&hashers[1]);
@@ -700,6 +700,8 @@ static bool signing_sign_input(void) {
 		return false;
 	}
 
+	uint32_t hash_type = signing_hash_type();
+	sha256_Update(&ti.ctx, (const uint8_t *)&hash_type, 4);
 	tx_hash_final(&ti, hash, false);
 	resp.has_serialized = true;
 	if (!signing_sign_hash(&input, privkey, pubkey, hash))
@@ -867,7 +869,7 @@ void signing_txack(TransactionType *tx)
 			}
 			return;
 		case STAGE_REQUEST_2_PREV_META:
-			tx_init(&tp, tx->inputs_cnt, tx->outputs_cnt, tx->version, tx->lock_time, tx->extra_data_len, false);
+			tx_init(&tp, tx->inputs_cnt, tx->outputs_cnt, tx->version, tx->lock_time, tx->extra_data_len);
 			progress_meta_step = progress_step / (tp.inputs_len + tp.outputs_len);
 			idx2 = 0;
 			if (tp.inputs_len > 0) {
@@ -940,7 +942,7 @@ void signing_txack(TransactionType *tx)
 		case STAGE_REQUEST_4_INPUT:
 			progress = 500 + ((signatures * progress_step + idx2 * progress_meta_step) >> PROGRESS_PRECISION);
 			if (idx2 == 0) {
-				tx_init(&ti, inputs_count, outputs_count, version, lock_time, 0, true);
+				tx_init(&ti, inputs_count, outputs_count, version, lock_time, 0);
 				sha256_Init(&hashers[0]);
 			}
 			// check prevouts and script type

--- a/firmware/transaction.c
+++ b/firmware/transaction.c
@@ -455,25 +455,13 @@ uint32_t tx_serialize_middle_hash(TxStruct *tx)
 uint32_t tx_serialize_footer(TxStruct *tx, uint8_t *out)
 {
 	memcpy(out, &(tx->lock_time), 4);
-	if (tx->add_hash_type) {
-		uint32_t ht = 1;
-		memcpy(out + 4, &ht, 4);
-		return 8;
-	} else {
-		return 4;
-	}
+	return 4;
 }
 
 uint32_t tx_serialize_footer_hash(TxStruct *tx)
 {
 	sha256_Update(&(tx->ctx), (const uint8_t *)&(tx->lock_time), 4);
-	if (tx->add_hash_type) {
-		uint32_t ht = 1;
-		sha256_Update(&(tx->ctx), (const uint8_t *)&ht, 4);
-		return 8;
-	} else {
-		return 4;
-	}
+	return 4;
 }
 
 uint32_t tx_serialize_output(TxStruct *tx, const TxOutputBinType *output, uint8_t *out)
@@ -545,13 +533,12 @@ uint32_t tx_serialize_extra_data_hash(TxStruct *tx, const uint8_t *data, uint32_
 	return datalen;
 }
 
-void tx_init(TxStruct *tx, uint32_t inputs_len, uint32_t outputs_len, uint32_t version, uint32_t lock_time, uint32_t extra_data_len, bool add_hash_type)
+void tx_init(TxStruct *tx, uint32_t inputs_len, uint32_t outputs_len, uint32_t version, uint32_t lock_time, uint32_t extra_data_len)
 {
 	tx->inputs_len = inputs_len;
 	tx->outputs_len = outputs_len;
 	tx->version = version;
 	tx->lock_time = lock_time;
-	tx->add_hash_type = add_hash_type;
 	tx->have_inputs = 0;
 	tx->have_outputs = 0;
 	tx->extra_data_len = extra_data_len;

--- a/firmware/transaction.h
+++ b/firmware/transaction.h
@@ -33,7 +33,7 @@ typedef struct {
 
 	uint32_t version;
 	uint32_t lock_time;
-	bool add_hash_type, is_segwit;
+	bool is_segwit;
 
 	uint32_t have_inputs;
 	uint32_t have_outputs;
@@ -64,7 +64,7 @@ uint32_t tx_serialize_footer(TxStruct *tx, uint8_t *out);
 uint32_t tx_serialize_input(TxStruct *tx, const TxInputType *input, uint8_t *out);
 uint32_t tx_serialize_output(TxStruct *tx, const TxOutputBinType *output, uint8_t *out);
 
-void tx_init(TxStruct *tx, uint32_t inputs_len, uint32_t outputs_len, uint32_t version, uint32_t lock_time, uint32_t extra_data_len, bool add_hash_type);
+void tx_init(TxStruct *tx, uint32_t inputs_len, uint32_t outputs_len, uint32_t version, uint32_t lock_time, uint32_t extra_data_len);
 uint32_t tx_serialize_header_hash(TxStruct *tx);
 uint32_t tx_serialize_input_hash(TxStruct *tx, const TxInputType *input);
 uint32_t tx_serialize_output_hash(TxStruct *tx, const TxOutputBinType *output);


### PR DESCRIPTION
This is not tested against Bitcoin Gold but it has not broken Bitcoin or Bitcoin Cash. All hardcoded instances of `SIGHASH_ALL` have been removed.

/cc @jhoenicke 