### PR TITLE
Disable swipe with DEBUG_LINK

### DIFF
--- a/firmware/layout2.c
+++ b/firmware/layout2.c
@@ -38,10 +38,19 @@
 
 void *layoutLast = layoutHome;
 
+void layoutSwipe(void) {
+#if DEBUG_LINK
+	oledClear();
+#else
+	oledSwipeLeft();
+#endif
+}
+
+
 void layoutDialogSwipe(const BITMAP *icon, const char *btnNo, const char *btnYes, const char *desc, const char *line1, const char *line2, const char *line3, const char *line4, const char *line5, const char *line6)
 {
 	layoutLast = layoutDialogSwipe;
-	oledSwipeLeft();
+	layoutSwipe();
 	layoutDialog(icon, btnNo, btnYes, desc, line1, line2, line3, line4, line5, line6);
 }
 
@@ -51,7 +60,7 @@ void layoutProgressSwipe(const char *desc, int permil)
 		oledClear();
 	} else {
 		layoutLast = layoutProgressSwipe;
-		oledSwipeLeft();
+		layoutSwipe();
 	}
 	layoutProgress(desc, permil);
 }
@@ -68,7 +77,7 @@ void layoutHome(void)
 	if (layoutLast == layoutHome || layoutLast == layoutScreensaver) {
 		oledClear();
 	} else {
-		oledSwipeLeft();
+		layoutSwipe();
 	}
 	layoutLast = layoutHome;
 	const char *label = storage_isInitialized() ? storage_getLabel() : _("Go to trezor.io/start");
@@ -225,7 +234,7 @@ void layoutDecryptMessage(const uint8_t *msg, uint32_t len, const char *address)
 void layoutResetWord(const char *word, int pass, int word_pos, bool last)
 {
 	layoutLast = layoutResetWord;
-	oledSwipeLeft();
+	layoutSwipe();
 
 	const char *btnYes;
 	if (last) {
@@ -280,7 +289,7 @@ void layoutResetWord(const char *word, int pass, int word_pos, bool last)
 void layoutAddress(const char *address, const char *desc, bool qrcode)
 {
 	if (layoutLast != layoutAddress) {
-		oledSwipeLeft();
+		layoutSwipe();
 	} else {
 		oledClear();
 	}

--- a/firmware/layout2.h
+++ b/firmware/layout2.h
@@ -24,8 +24,11 @@
 #include "types.pb.h"
 #include "bitmaps.h"
 #include "bignum.h"
+#include "trezor.h"
 
 extern void *layoutLast;
+
+void layoutSwipe(void);
 
 void layoutDialogSwipe(const BITMAP *icon, const char *btnNo, const char *btnYes, const char *desc, const char *line1, const char *line2, const char *line3, const char *line4, const char *line5, const char *line6);
 void layoutProgressSwipe(const char *desc, int permil);

--- a/firmware/pinmatrix.c
+++ b/firmware/pinmatrix.c
@@ -20,6 +20,7 @@
 #include <string.h>
 
 #include "pinmatrix.h"
+#include "layout2.h"
 #include "oled.h"
 #include "rng.h"
 
@@ -31,7 +32,7 @@ void pinmatrix_draw(const char *text)
 		&bmp_digit0, &bmp_digit1, &bmp_digit2, &bmp_digit3, &bmp_digit4,
 		&bmp_digit5, &bmp_digit6, &bmp_digit7, &bmp_digit8, &bmp_digit9,
 	};
-	oledSwipeLeft();
+	layoutSwipe();
 	const int w = bmp_digit0.width, h = bmp_digit0.height, pad = 2;
 	for (int i = 0; i < 3; i++) {
 		for (int j = 0; j < 3; j++) {


### PR DESCRIPTION
This greatly reduces the amount of time that device tests take. With SegWit native device test, it reduced the time by 40%.