### PR TITLE
Support for generic ECDSA signing

### DIFF
--- a/firmware/crypto.c
+++ b/firmware/crypto.c
@@ -110,6 +110,12 @@ int gpgMessageSign(HDNode *node, const uint8_t *message, size_t message_len, uin
 	}
 }
 
+int ecdsaMessageSign(HDNode *node, const uint8_t *message, size_t message_len, uint8_t *signature)
+{
+	signature[0] = 0; // prefix: pad with zero, so all signatures are 65 bytes
+	return hdnode_sign(node, message, message_len, signature + 1, NULL, NULL);
+}
+
 int cryptoMessageSign(const CoinType *coin, HDNode *node, InputScriptType script_type, const uint8_t *message, size_t message_len, uint8_t *signature)
 {
 	SHA256_CTX ctx;

--- a/firmware/crypto.h
+++ b/firmware/crypto.h
@@ -37,6 +37,8 @@ int sshMessageSign(HDNode *node, const uint8_t *message, size_t message_len, uin
 
 int gpgMessageSign(HDNode *node, const uint8_t *message, size_t message_len, uint8_t *signature);
 
+int ecdsaMessageSign(HDNode *node, const uint8_t *message, size_t message_len, uint8_t *signature);
+
 int cryptoMessageSign(const CoinType *coin, HDNode *node, InputScriptType script_type, const uint8_t *message, size_t message_len, uint8_t *signature);
 
 int cryptoMessageVerify(const CoinType *coin, const uint8_t *message, size_t message_len, uint32_t address_type, const uint8_t *address_raw, const uint8_t *signature);

--- a/firmware/fsm.h
+++ b/firmware/fsm.h
@@ -51,6 +51,7 @@ void fsm_msgEntropyAck(EntropyAck *msg);
 void fsm_msgSignMessage(SignMessage *msg);
 void fsm_msgVerifyMessage(VerifyMessage *msg);
 void fsm_msgSignIdentity(SignIdentity *msg);
+void fsm_msgSignEcdsa(SignEcdsa *msg);
 void fsm_msgGetECDHSessionKey(GetECDHSessionKey *msg);
 /* ECIES disabled
 void fsm_msgEncryptMessage(EncryptMessage *msg);

--- a/firmware/layout2.c
+++ b/firmware/layout2.c
@@ -21,6 +21,7 @@
 #include <string.h>
 #include <ctype.h>
 
+#include "crypto.h"
 #include "layout2.h"
 #include "storage.h"
 #include "oled.h"
@@ -415,6 +416,24 @@ void layoutSignIdentity(const IdentityType *identity, const char *challenge)
 		row_hostport[0] ? row_hostport : NULL,
 		row_user[0] ? row_user : NULL,
 		challenge,
+		NULL,
+		NULL);
+}
+
+void layoutSignEcdsa(const SignEcdsa *signEcdsa)
+{
+    // Calculate sha256 hash (+1 null byte)
+    char hashHex[65];
+    sha256_Data(signEcdsa->blob.bytes, signEcdsa->blob.size, hashHex);
+
+    const char **str = split_message((const uint8_t *)hashHex, 64, 16);
+
+	layoutDialogSwipe(&bmp_icon_question, _("Cancel"), _("Sign"),
+		_("^ data has this SHA256 ^"),
+		str[0],
+		str[1],
+		str[2],
+		str[3],
 		NULL,
 		NULL);
 }

--- a/firmware/layout2.h
+++ b/firmware/layout2.h
@@ -22,6 +22,7 @@
 
 #include "layout.h"
 #include "types.pb.h"
+#include "messages.pb.h"
 #include "bitmaps.h"
 #include "bignum.h"
 #include "trezor.h"
@@ -52,6 +53,7 @@ void layoutResetWord(const char *word, int pass, int word_pos, bool last);
 void layoutAddress(const char *address, const char *desc, bool qrcode);
 void layoutPublicKey(const uint8_t *pubkey);
 void layoutSignIdentity(const IdentityType *identity, const char *challenge);
+void layoutSignEcdsa(const SignEcdsa *signEcdsa);
 void layoutDecryptIdentity(const IdentityType *identity);
 void layoutU2FDialog(const char *verb, const char *appname, const BITMAP *appicon);
 

--- a/firmware/protob/messages.options
+++ b/firmware/protob/messages.options
@@ -137,6 +137,15 @@ SignedIdentity.address			max_size:60
 SignedIdentity.public_key		max_size:33
 SignedIdentity.signature		max_size:65
 
+SignEcdsa.address_n             max_count:8
+SignEcdsa.blob		            max_size:1024
+SignEcdsa.challenge_visual		max_size:256
+SignEcdsa.ecdsa_curve_name		max_size:32
+
+SignedEcdsa.address			max_size:60
+SignedEcdsa.public_key		max_size:33
+SignedEcdsa.signature		max_size:65
+
 GetECDHSessionKey.peer_public_key	max_size:65
 GetECDHSessionKey.ecdsa_curve_name	max_size:32
 


### PR DESCRIPTION
I've implemented generic ECDSA signing because I'd like to add support for signing Stellar transactions. This PR adds a generic method that I'll use to build out additional features for Stellar in the future.

`fsm_msgSignIdentity` came close to what I wanted, but it didn't support an arbitrary bip32 path or provide a way to confirm the hash of the data being signed.

This also relies on a PR submitted to trezor-common: https://github.com/trezor/trezor-common/pull/53