### PR TITLE
Confirm lock time on device

### DIFF
--- a/firmware/layout2.h
+++ b/firmware/layout2.h
@@ -44,6 +44,7 @@ void layoutConfirmOutput(const CoinInfo *coin, const TxOutputType *out);
 void layoutConfirmOpReturn(const uint8_t *data, uint32_t size);
 void layoutConfirmTx(const CoinInfo *coin, uint64_t amount_out, uint64_t amount_fee);
 void layoutFeeOverThreshold(const CoinInfo *coin, uint64_t fee);
+void layoutLockTime(uint32_t lock_time);
 void layoutSignMessage(const uint8_t *msg, uint32_t len);
 void layoutVerifyAddress(const char *address);
 void layoutVerifyMessage(const uint8_t *msg, uint32_t len);

--- a/firmware/signing.c
+++ b/firmware/signing.c
@@ -610,6 +610,14 @@ static bool signing_check_fee(void) {
 			return false;
 		}
 	}
+	if (lock_time != 0) {
+		layoutLockTime(lock_time);
+		if (!protectButton(ButtonRequestType_ButtonRequest_ConfirmOutput, false)) {
+			fsm_sendFailure(FailureType_Failure_ActionCancelled, NULL);
+			signing_abort();
+			return false;
+		}
+	}
 	// last confirmation
 	layoutConfirmTx(coin, to_spend - change_spend, fee);
 	if (!protectButton(ButtonRequestType_ButtonRequest_SignTx, false)) {


### PR DESCRIPTION
Asks user to confirm lock time as block height (`block #1`) or date (`01 Jan 1970 00:00 UTC`).

Does not display seconds and only supports UTC.

Fixes #233