### PR TITLE
Ask user to confirm passphrase

### DIFF
--- a/firmware/layout2.c
+++ b/firmware/layout2.c
@@ -124,6 +124,14 @@ void layoutHome(void)
 	system_millis_lock_start = timer_ms();
 }
 
+void layoutPassphrase(const char *passphrase, size_t length)
+{
+	const char **str = split_message((uint8_t *) passphrase, length, 16);
+	layoutDialogSwipe(&bmp_icon_question, NULL, _("Continue"),
+		_("Use passphrase?"),
+		str[0], str[1], str[2], str[3], NULL, NULL);
+}
+
 void layoutConfirmOutput(const CoinInfo *coin, const TxOutputType *out)
 {
 	char str_out[32];

--- a/firmware/layout2.h
+++ b/firmware/layout2.h
@@ -40,6 +40,7 @@ void layoutProgressSwipe(const char *desc, int permil);
 
 void layoutScreensaver(void);
 void layoutHome(void);
+void layoutPassphrase(const char *passphrase, size_t length);
 void layoutConfirmOutput(const CoinInfo *coin, const TxOutputType *out);
 void layoutConfirmOpReturn(const uint8_t *data, uint32_t size);
 void layoutConfirmTx(const CoinInfo *coin, uint64_t amount_out, uint64_t amount_fee);

--- a/firmware/protect.c
+++ b/firmware/protect.c
@@ -35,6 +35,8 @@
 
 bool protectAbortedByInitialize = false;
 
+static uint8_t CONFIDENTIAL passphraseHash[SHA256_DIGEST_LENGTH];
+
 bool protectButton(ButtonRequestType type, bool confirm_only)
 {
 	ButtonRequest resp;
@@ -237,9 +239,6 @@ bool protectChangePin(void)
 	return result;
 }
 
-
-static uint8_t passphraseHash[32];
-
 bool protectPassphrase(void)
 {
 	if (!storage_hasPassphraseProtection() || session_isPassphraseCached()) {
@@ -262,10 +261,10 @@ bool protectPassphrase(void)
 
 			size_t length = strlen(ppa->passphrase);
 			if (length > 0) {
-				uint8_t hash[32];
+				uint8_t hash[SHA256_DIGEST_LENGTH];
 				sha256_Raw((const uint8_t *)(ppa->passphrase), length, hash);
 
-				bool sameAsLast = memcmp(hash, passphraseHash, 32) == 0;
+				bool sameAsLast = memcmp(hash, passphraseHash, SHA256_DIGEST_LENGTH) == 0;
 
 				if (!sameAsLast) {
 					layoutPassphrase(ppa->passphrase, length);

--- a/firmware/protect.c
+++ b/firmware/protect.c
@@ -255,6 +255,16 @@ bool protectPassphrase(void)
 		if (msg_tiny_id == MessageType_MessageType_PassphraseAck) {
 			msg_tiny_id = 0xFFFF;
 			PassphraseAck *ppa = (PassphraseAck *)msg_tiny;
+
+			size_t length = strlen(ppa->passphrase);
+			if (length > 0) {
+				layoutPassphrase(ppa->passphrase, length);
+				if (!protectButton(ButtonRequestType_ButtonRequest_ProtectCall, true)) {
+					result = false;
+					break;
+				}
+			}
+
 			session_cachePassphrase(ppa->passphrase);
 			result = true;
 			break;


### PR DESCRIPTION
Asks the user to confirm the passphrase before using it.

Perhaps we should not allow the user to cancel the passphrase as the UX with TREZOR Wallet is terrible. Rather than asking again for the passphrase, TREZOR Wallet will keep sending the same passphrase unless the device is reattached or the page reloaded.

Fixes #62