### PR TITLE
Add IOTA support

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -13,3 +13,6 @@
 [submodule "vendor/nanopb"]
 	path = vendor/nanopb
 	url = https://github.com/nanopb/nanopb.git
+[submodule "vendor/iota"]
+	path = vendor/iota
+	url = https://github.com/iota-trezor/iota.git

--- a/firmware/Makefile
+++ b/firmware/Makefile
@@ -26,6 +26,7 @@ OBJS += ethereum.o
 OBJS += ethereum_tokens.o
 OBJS += nem2.o
 OBJS += nem_mosaics.o
+OBJS += iota.o
 
 OBJS += debug.o
 
@@ -67,6 +68,12 @@ OBJS += ../vendor/trezor-crypto/aes/aes_modes.o
 OBJS += ../vendor/trezor-crypto/nem.o
 
 OBJS += ../vendor/trezor-qrenc/qr_encode.o
+
+OBJS += ../vendor/iota/addresses.o
+OBJS += ../vendor/iota/bigint.o
+OBJS += ../vendor/iota/conversion.o
+OBJS += ../vendor/iota/kerl.o
+OBJS += ../vendor/iota/transaction.o
 
 # OBJS += protob/pb_common.o
 OBJS += protob/pb_decode.o

--- a/firmware/fsm.c
+++ b/firmware/fsm.c
@@ -1605,8 +1605,18 @@ void fsm_msgIotaTxRequest(IotaTxRequest *msg)
 		return;
 	}
 
+	memset(str_one, 0, sizeof(str_one));
+	memcpy(str_one, tx.tag, 27);
+	// Remove trailing 9's
+	for (int i = 27-1; i > 0; i--) {
+		if (str_one[i] == '9') {
+			str_one[i] = '\0';
+		} else {
+			break;
+		}
+	}
 	bn_format_uint64(tx.timestamp, "", "", 0, 0, false, str_two, 30);
-	layoutDialogSwipe(&bmp_icon_question, _("Cancel"), _("Sign"), _("Sign transaction"), _("Tag:"), _("TREZOR"), _("Request timestamp:"), str_two, NULL, NULL);
+	layoutDialogSwipe(&bmp_icon_question, _("Cancel"), _("Sign"), _("Sign transaction"), _("Tag:"), str_one, _("Request timestamp:"), str_two, NULL, NULL);
 	if (!protectButton(ButtonRequestType_ButtonRequest_ProtectCall, false)) {
 		fsm_sendFailure(FailureType_Failure_ActionCancelled, NULL);
 		layoutHome();

--- a/firmware/fsm.c
+++ b/firmware/fsm.c
@@ -1480,6 +1480,20 @@ void fsm_msgIotaGetAddressCounter(IotaGetAddressCounter *msg)
 
 	resp->address_counter = storage_GetIotaAddressCounter();
 	resp->has_address_counter = true;
+
+	char str[20] = {0};
+	bn_format_uint64(resp->address_counter, "", "", 0, 0, 0, str, 20);
+	layoutDialogSwipe(&bmp_icon_info, NULL, _("Continue"),
+		NULL,
+		_("IOTA address"),
+		_("counter:"),
+		str, NULL, NULL, NULL);
+	if (!protectButton(ButtonRequestType_ButtonRequest_ProtectCall, true)) {
+		fsm_sendFailure(FailureType_Failure_ActionCancelled, NULL);
+		layoutHome();
+		return;
+	}
+
 	msg_write(MessageType_MessageType_IotaAddressCounter, resp);
 	layoutHome();
 }

--- a/firmware/fsm.c
+++ b/firmware/fsm.c
@@ -1533,6 +1533,7 @@ void fsm_msgIotaGetAddress(IotaGetAddress *msg)
 	// Take address counter from message if available, otherwise from storage
 	uint32_t address_index = (msg->has_address_index ? msg->address_index : storage_GetIotaAddressCounter());
 	iota_address_from_seed_with_index(address_index, false, resp->address);
+	resp->has_address = true;
 	resp->address_index = address_index;
 	resp->has_address_index = true;
 

--- a/firmware/fsm.h
+++ b/firmware/fsm.h
@@ -72,12 +72,10 @@ void fsm_msgNEMSignTx(NEMSignTx *msg);
 void fsm_msgCosiCommit(CosiCommit *msg);
 void fsm_msgCosiSign(CosiSign *msg);
 
-void fsm_msgIotaShowSeed(IotaShowSeed *msg);
 void fsm_msgIotaGetAddressCounter(IotaGetAddressCounter *msg);
 void fsm_msgIotaSetAddressCounter(IotaSetAddressCounter *msg);
 void fsm_msgIotaGetAddress(IotaGetAddress *msg);
 void fsm_msgIotaTxRequest(IotaTxRequest *msg);
-void fsm_msgIotaTxDetails(IotaTxDetails *msg);
 
 // debug message functions
 #if DEBUG_LINK

--- a/firmware/fsm.h
+++ b/firmware/fsm.h
@@ -72,6 +72,13 @@ void fsm_msgNEMSignTx(NEMSignTx *msg);
 void fsm_msgCosiCommit(CosiCommit *msg);
 void fsm_msgCosiSign(CosiSign *msg);
 
+void fsm_msgIotaShowSeed(IotaShowSeed *msg);
+void fsm_msgIotaGetAddressCounter(IotaGetAddressCounter *msg);
+void fsm_msgIotaSetAddressCounter(IotaSetAddressCounter *msg);
+void fsm_msgIotaGetAddress(IotaGetAddress *msg);
+void fsm_msgIotaTxRequest(IotaTxRequest *msg);
+void fsm_msgIotaTxDetails(IotaTxDetails *msg);
+
 // debug message functions
 #if DEBUG_LINK
 //void fsm_msgDebugLinkDecision(DebugLinkDecision *msg);

--- a/firmware/iota.c
+++ b/firmware/iota.c
@@ -31,7 +31,6 @@ void iota_address_generation_progress_callback(uint32_t progress)
 	layoutProgress(_("Generating address."), progress);
 }
 
-
 void iota_signing_transaction_progress_one_callback(uint32_t progress)
 {
 	layoutProgress(_("Signing transaction."), progress/2);
@@ -179,7 +178,7 @@ bool iota_sign_transaction(iota_transaction_details_type *tx, char bundle_hash[]
 	generate_private_key(seed_trits, tx->input_address_index, private_key_trits);
 
 	// Sign inputs
-	if(1){
+	{
 		trit_t first_signature_trits[3*27*81];
 		tryte_t first_signature_trytes[27*81];
 		generate_signature_fragment(&normalized_bundle_hash[0], &private_key_trits[0], first_signature_trits, iota_signing_transaction_progress_one_callback);
@@ -187,7 +186,8 @@ bool iota_sign_transaction(iota_transaction_details_type *tx, char bundle_hash[]
 		trytes_to_chars(first_signature_trytes, first_signature, 27*81);
 	}
 
-	if(1){
+	// Second signature
+	{
 		trit_t second_signature_trits[3*27*81];
 		tryte_t second_signature_trytes[27*81];
 		generate_signature_fragment(&normalized_bundle_hash[27], &private_key_trits[6561], second_signature_trits, iota_signing_transaction_progress_two_callback);

--- a/firmware/iota.c
+++ b/firmware/iota.c
@@ -1,0 +1,210 @@
+/*
+ * This file is part of the IOTA-TREZOR project.
+ *
+ * Copyright (C) 2017 Bart Slinger <bartslinger@gmail.com>
+ *
+ * This library is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this library.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "iota.h"
+#include "vendor/iota/kerl.h"
+#include "vendor/iota/conversion.h"
+#include "vendor/iota/addresses.h"
+#include "vendor/iota/transaction.h"
+#include <string.h>
+
+static CONFIDENTIAL struct iota_data_struct iota_data = {0};
+static iota_unsigned_transaction_type iota_unsigned_transaction = {0};
+
+void iota_address_generation_progress_callback(uint32_t progress)
+{
+	layoutProgress(_("Generating address."), progress);
+}
+
+
+void iota_signing_transaction_progress_one_callback(uint32_t progress)
+{
+	layoutProgress(_("Signing transaction."), progress/2);
+}
+
+void iota_signing_transaction_progress_two_callback(uint32_t progress)
+{
+	layoutProgress(_("Signing transaction."), 500 + progress/2);
+}
+
+bool iota_initialize(HDNode *node)
+{
+	// Has to be called before calling any of the other functions in this file.
+	// It does the following steps:
+	// 1. Get seed from mnemonic
+
+	if (!node)
+		return false;
+	iota_data.node = node;
+
+	// We will always need the seed, doesn't take much time.
+	iota_get_seed();
+
+	// Make sure we have an address counter in storage.
+	if (!storage.has_iota_address_counter) {
+		storage_setIotaAddressCounter(0);
+	}
+
+	return true;
+}
+
+const char* iota_get_seed()
+{
+	if (!iota_data.seed_ready) {
+		// generate seed from mnemonic
+		if (iota_data.node == NULL) {
+			while(1) {} // just in case, prevent using empty key
+		}
+
+		uint8_t derived_seed[64];
+		memcpy(&derived_seed[0], iota_data.node->private_key, 32);
+		memcpy(&derived_seed[32], iota_data.node->chain_code, 32);
+
+		kerl_initialize();
+
+		// Absorb 4 times using sliding window:
+		// Divide 64 byte trezor-seed in 4 sections of 16 bytes.
+		// 1: [123.] first 48 bytes
+		// 2: [.123] last 48 bytes
+		// 3: [3.12] last 32 bytes + first 16 bytes
+		// 4: [23.1] last 16 bytes + first 32 bytes
+		unsigned char bytes_in[48];
+
+		// Step 1.
+		memcpy(&bytes_in[0], derived_seed, 48);
+		kerl_absorb_bytes(bytes_in, 48);
+
+		// Step 2.
+		memcpy(&bytes_in[0], derived_seed+16, 48);
+		kerl_absorb_bytes(bytes_in, 48);
+
+		// Step 3.
+		memcpy(&bytes_in[0], derived_seed+32, 32);
+		memcpy(&bytes_in[32], derived_seed, 16);
+		kerl_absorb_bytes(bytes_in, 48);
+
+		// Step 4.
+		memcpy(&bytes_in[0], derived_seed+48, 16);
+		memcpy(&bytes_in[16], derived_seed, 32);
+		kerl_absorb_bytes(bytes_in, 48);
+
+		// Squeeze out the seed
+		trit_t seed_trits[243];
+		kerl_squeeze_trits(seed_trits, 243);
+		tryte_t seed_trytes[81];
+		trits_to_trytes(seed_trits, seed_trytes, 243);
+		trytes_to_chars(seed_trytes, iota_data.seed, 81);
+
+		iota_data.seed_ready = true;
+	}
+	return iota_data.seed;
+}
+
+void iota_address_from_seed_with_index(uint32_t index, bool display, char public_address[])
+{
+	const char* iota_seed = iota_get_seed();
+
+	// Seed to trits
+	trit_t seed_trits[243];
+	{
+		tryte_t seed_trytes[81];
+		chars_to_trytes(iota_seed, seed_trytes, 81);
+		trytes_to_trits(seed_trytes, seed_trits, 81);
+	}
+
+	{
+		tryte_t pubkey_addr[81];
+		trit_t private_key_trits[243*27*2];
+		generate_private_key(seed_trits, index, private_key_trits);
+		trit_t public_address_trits[243];
+		generate_public_address(private_key_trits, public_address_trits, iota_address_generation_progress_callback);
+
+		trits_to_trytes(public_address_trits, pubkey_addr, 243);
+		trytes_to_chars(pubkey_addr, public_address, 81);
+	}
+
+	if(display) {
+		layoutIotaAddress(public_address, "IOTA  receive address:");
+	}
+}
+
+bool iota_sign_transaction(uint64_t transaction_timestamp, char bundle_hash[], char first_signature[], char second_signature[])
+{
+	if (!iota_unsigned_transaction.ready_for_signing) {
+		return false;
+	}
+
+	iota_signing_transaction_progress_one_callback(0);
+
+	tryte_t normalized_bundle_hash[81];
+	{
+		tryte_t bundle_hash_trytes[81];
+		calculate_standard_bundle_hash(iota_unsigned_transaction.input_address,
+									   iota_unsigned_transaction.receiving_address,
+									   iota_unsigned_transaction.remainder_address,
+									   iota_unsigned_transaction.balance,
+									   iota_unsigned_transaction.transfer_amount,
+									   iota_unsigned_transaction.tag,
+									   transaction_timestamp,
+									   bundle_hash_trytes);
+		trytes_to_chars(bundle_hash_trytes, bundle_hash, 81);
+		normalize_hash(bundle_hash_trytes, normalized_bundle_hash);
+	}
+
+	// We will also need the private key of the first address
+	// Seed to trits
+	trit_t seed_trits[243];
+	{
+		tryte_t seed_trytes[81];
+		chars_to_trytes(iota_data.seed, seed_trytes, 81);
+		trytes_to_trits(seed_trytes, seed_trits, 81);
+	}
+
+	trit_t private_key_trits[243*27*2];
+	generate_private_key(seed_trits, iota_unsigned_transaction.input_address_index, private_key_trits);
+
+	// Sign inputs
+	if(1){
+		trit_t first_signature_trits[3*27*81];
+		tryte_t first_signature_trytes[27*81];
+		generate_signature_fragment(&normalized_bundle_hash[0], &private_key_trits[0], first_signature_trits, iota_signing_transaction_progress_one_callback);
+		trits_to_trytes(first_signature_trits, first_signature_trytes, 3*27*81);
+		trytes_to_chars(first_signature_trytes, first_signature, 27*81);
+	}
+
+	if(1){
+		trit_t second_signature_trits[3*27*81];
+		tryte_t second_signature_trytes[27*81];
+		generate_signature_fragment(&normalized_bundle_hash[27], &private_key_trits[6561], second_signature_trits, iota_signing_transaction_progress_two_callback);
+		trits_to_trytes(second_signature_trits, second_signature_trytes, 3*27*81);
+		trytes_to_chars(second_signature_trytes, second_signature, 27*81);
+	}
+
+	return true;
+}
+
+iota_unsigned_transaction_type* iota_unsigned_transaction_get()
+{
+	return &iota_unsigned_transaction;
+}
+
+void iota_unsigned_transaction_erase()
+{
+	memset(&iota_unsigned_transaction, 0, sizeof(iota_unsigned_transaction_type));
+}

--- a/firmware/iota.c
+++ b/firmware/iota.c
@@ -25,7 +25,6 @@
 #include <string.h>
 
 static CONFIDENTIAL struct iota_data_struct iota_data = {0};
-static iota_unsigned_transaction_type iota_unsigned_transaction = {0};
 
 void iota_address_generation_progress_callback(uint32_t progress)
 {
@@ -144,9 +143,9 @@ void iota_address_from_seed_with_index(uint32_t index, bool display, char public
 	}
 }
 
-bool iota_sign_transaction(uint64_t transaction_timestamp, char bundle_hash[], char first_signature[], char second_signature[])
+bool iota_sign_transaction(iota_transaction_details_type *tx, char bundle_hash[], char first_signature[], char second_signature[])
 {
-	if (!iota_unsigned_transaction.ready_for_signing) {
+	if (!tx->ready_for_signing) {
 		return false;
 	}
 
@@ -155,13 +154,13 @@ bool iota_sign_transaction(uint64_t transaction_timestamp, char bundle_hash[], c
 	tryte_t normalized_bundle_hash[81];
 	{
 		tryte_t bundle_hash_trytes[81];
-		calculate_standard_bundle_hash(iota_unsigned_transaction.input_address,
-									   iota_unsigned_transaction.receiving_address,
-									   iota_unsigned_transaction.remainder_address,
-									   iota_unsigned_transaction.balance,
-									   iota_unsigned_transaction.transfer_amount,
-									   iota_unsigned_transaction.tag,
-									   transaction_timestamp,
+		calculate_standard_bundle_hash(tx->input_address,
+									   tx->receiving_address,
+									   tx->remainder_address,
+									   tx->balance,
+									   tx->transfer_amount,
+									   tx->tag,
+									   tx->timestamp,
 									   bundle_hash_trytes);
 		trytes_to_chars(bundle_hash_trytes, bundle_hash, 81);
 		normalize_hash(bundle_hash_trytes, normalized_bundle_hash);
@@ -177,7 +176,7 @@ bool iota_sign_transaction(uint64_t transaction_timestamp, char bundle_hash[], c
 	}
 
 	trit_t private_key_trits[243*27*2];
-	generate_private_key(seed_trits, iota_unsigned_transaction.input_address_index, private_key_trits);
+	generate_private_key(seed_trits, tx->input_address_index, private_key_trits);
 
 	// Sign inputs
 	if(1){
@@ -197,14 +196,4 @@ bool iota_sign_transaction(uint64_t transaction_timestamp, char bundle_hash[], c
 	}
 
 	return true;
-}
-
-iota_unsigned_transaction_type* iota_unsigned_transaction_get()
-{
-	return &iota_unsigned_transaction;
-}
-
-void iota_unsigned_transaction_erase()
-{
-	memset(&iota_unsigned_transaction, 0, sizeof(iota_unsigned_transaction_type));
 }

--- a/firmware/iota.h
+++ b/firmware/iota.h
@@ -44,17 +44,16 @@ typedef struct {
 	char input_address[81];
 	uint32_t remainder_address_index;
 	char remainder_address[81];
-	uint64_t request_timestamp;
+	uint64_t timestamp;
 	uint64_t transfer_amount;
 	uint64_t balance;
 	char tag[27];
-} iota_unsigned_transaction_type;
+} iota_transaction_details_type;
 
 bool iota_initialize(HDNode *node);
 const char *iota_get_seed(void);
 void iota_address_from_seed_with_index(uint32_t index, bool display, char public_address[]);
 void iota_unsigned_transaction_erase(void);
-iota_unsigned_transaction_type* iota_unsigned_transaction_get(void);
-bool iota_sign_transaction(uint64_t transaction_timestamp, char bundle_hash[], char first_signature[], char second_signature[]);
+bool iota_sign_transaction(iota_transaction_details_type* transaction_details, char bundle_hash[], char first_signature[], char second_signature[]);
 
 #endif

--- a/firmware/iota.h
+++ b/firmware/iota.h
@@ -1,0 +1,60 @@
+/*
+ * This file is part of the IOTA-TREZOR project.
+ *
+ * Copyright (C) 2017 Bart Slinger <bartslinger@gmail.com>
+ *
+ * This library is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this library.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#ifndef __IOTA_H__
+#define __IOTA_H__
+
+#include <stdint.h>
+#include <stdbool.h>
+#include "fsm.h"
+#include "gettext.h"
+#include "layout2.h"
+#include "messages.h"
+#include "storage.h"
+
+// "IOTA" in hex
+#define IOTA_KEY_PATH 0x494f5441
+
+struct iota_data_struct {
+	char seed[81];
+	bool seed_ready;
+	HDNode* node;
+};
+
+typedef struct {
+	bool ready_for_signing;
+	char receiving_address[81];
+	uint32_t input_address_index;
+	char input_address[81];
+	uint32_t remainder_address_index;
+	char remainder_address[81];
+	uint64_t request_timestamp;
+	uint64_t transfer_amount;
+	uint64_t balance;
+	char tag[27];
+} iota_unsigned_transaction_type;
+
+bool iota_initialize(HDNode *node);
+const char *iota_get_seed(void);
+void iota_address_from_seed_with_index(uint32_t index, bool display, char public_address[]);
+void iota_unsigned_transaction_erase(void);
+iota_unsigned_transaction_type* iota_unsigned_transaction_get(void);
+bool iota_sign_transaction(uint64_t transaction_timestamp, char bundle_hash[], char first_signature[], char second_signature[]);
+
+#endif

--- a/firmware/iota.h
+++ b/firmware/iota.h
@@ -53,7 +53,6 @@ typedef struct {
 bool iota_initialize(HDNode *node);
 const char *iota_get_seed(void);
 void iota_address_from_seed_with_index(uint32_t index, bool display, char public_address[]);
-void iota_unsigned_transaction_erase(void);
 bool iota_sign_transaction(iota_transaction_details_type* transaction_details, char bundle_hash[], char first_signature[], char second_signature[]);
 
-#endif
+#endif // __IOTA_H__

--- a/firmware/layout2.c
+++ b/firmware/layout2.c
@@ -118,6 +118,7 @@ void layoutHome(void)
 		oledBox(0, 0, 127, 8, false);
 		oledDrawStringCenter(0, "NEEDS BACKUP!");
 	}
+
 	oledRefresh();
 
 	// Reset lock screen timeout
@@ -497,6 +498,19 @@ void layoutAddress(const char *address, const char *desc, bool qrcode, bool igno
 	oledDrawString(OLED_WIDTH - oledStringWidth(btnYes) - fontCharWidth('\x06') - 3, OLED_HEIGHT - 8, btnYes);
 	oledInvert(OLED_WIDTH - oledStringWidth(btnYes) - fontCharWidth('\x06') - 4, OLED_HEIGHT - 9, OLED_WIDTH - 1, OLED_HEIGHT - 1);
 
+	oledRefresh();
+}
+
+void layoutIotaAddress(const char *address, const char* descr)
+{
+	oledSwipeLeft();
+	oledDrawString(0, 0 * 9, descr);
+	for (int i = 0; i < 81; i++) {
+		int row = i / 14;
+		int col = i % 14;
+		int offset = (8 - fontCharWidth(address[i])) / 2;
+		oledDrawChar(col * 9 + offset, row * 9 + 10, address[i], 1);
+	}
 	oledRefresh();
 }
 

--- a/firmware/layout2.h
+++ b/firmware/layout2.h
@@ -52,6 +52,7 @@ void layoutEncryptMessage(const uint8_t *msg, uint32_t len, bool signing);
 void layoutDecryptMessage(const uint8_t *msg, uint32_t len, const char *address);
 void layoutResetWord(const char *word, int pass, int word_pos, bool last);
 void layoutAddress(const char *address, const char *desc, bool qrcode, bool ignorecase, const uint32_t *address_n, size_t address_n_count);
+void layoutIotaAddress(const char *address, const char *descr);
 void layoutPublicKey(const uint8_t *pubkey);
 void layoutSignIdentity(const IdentityType *identity, const char *challenge);
 void layoutDecryptIdentity(const IdentityType *identity);

--- a/firmware/protob/messages.options
+++ b/firmware/protob/messages.options
@@ -162,6 +162,15 @@ CosiSign.global_pubkey			max_size:32
 
 CosiSignature.signature			max_size:32
 
+IotaAddress.address			max_size:81
+
+IotaTxRequest.receiving_address	max_size:82
+IotaTxRequest.tag				max_size:28
+
+IotaSignedTx.bundlehash			max_size:81
+IotaSignedTx.first_signature	max_size:2187
+IotaSignedTx.second_signature	max_size:2187
+
 # deprecated
 SimpleSignTx				skip_message:true
 

--- a/firmware/protob/messages.options
+++ b/firmware/protob/messages.options
@@ -167,7 +167,7 @@ IotaAddress.address			max_size:81
 IotaTxRequest.receiving_address	max_size:82
 IotaTxRequest.tag				max_size:28
 
-IotaSignedTx.bundlehash			max_size:81
+IotaSignedTx.bundle_hash		max_size:81
 IotaSignedTx.first_signature	max_size:2187
 IotaSignedTx.second_signature	max_size:2187
 

--- a/firmware/storage.c
+++ b/firmware/storage.c
@@ -156,7 +156,7 @@ bool storage_from_flash(void)
 		old_storage_size = 1496;
 	} else
 	if (version == 8) {
-		old_storage_size = 1504;
+		old_storage_size = 1504 + 8; // Not sure: I added a uint32 and a bool
 	}
 
 	memset(&storage, 0, sizeof(Storage));
@@ -649,4 +649,19 @@ void storage_wipe(void)
 	storage_reset_uuid();
 	storage_commit();
 	storage_clearPinArea();
+}
+
+uint32_t storage_GetIotaAddressCounter()
+{
+	if (!storage.has_iota_address_counter) {
+		storage_setIotaAddressCounter(0);
+	}
+	return storage.iota_address_counter;
+}
+
+void storage_setIotaAddressCounter(uint32_t counter)
+{
+	storage.iota_address_counter = counter;
+	storage.has_iota_address_counter = true;
+	storage_commit();
 }

--- a/firmware/storage.h
+++ b/firmware/storage.h
@@ -66,6 +66,9 @@ uint32_t *storage_getPinFailsPtr(void);
 uint32_t storage_nextU2FCounter(void);
 void storage_setU2FCounter(uint32_t u2fcounter);
 
+uint32_t storage_GetIotaAddressCounter(void);
+void storage_setIotaAddressCounter(uint32_t counter);
+
 bool storage_isInitialized(void);
 
 bool storage_needsBackup(void);


### PR DESCRIPTION
Requires https://github.com/trezor/trezor-common/pull/61

IOTA uses completely different cryptography compared to other coins. I still derive the 'iota seed' from a HDNode, using path `m/IOTA'` with curve ED25519. This curve has no parameters, so effectively it just applies hmac_sha512. I use the output private key (32 bytes) and chain code (32 bytes) to form a 64-byte deterministic seed that I in turn use to generate a 81-tryte IOTA seed. With this method, I hoped to accomplish two things:
1. Deterministic IOTA addresses from a 24 words mnemonic
2. No security breach for other coins on the trezor if the IOTA seed gets compromised.

Generating public addresses on trezor takes around 12 seconds per address. I added an address counter in storage which keeps track of used addresses. The alternative would be to generate addresses until a balance is found. For each previous transaction, this would add 12 seconds to the login process, which I consider undesirable.

I'm not sure if it is correct to add 8 bytes for a uint32_t and a bool in firmware/storage.c

For signing transactions, the computer already has to know the send address, change address and corersponding address indices. This should be implemented in the computer side wallet.

The IOTA transaction should also include a relatively accurate timestamp. Depending on how long the user takes to verify the transaction by pushing buttons, the timestamp might get old. I implemented the following process to get a relatively accurate timestamp:
1. The user sends a transaction request to the trezor, including the current timestamp.
2. The user has to verify all the transaction details on the trezor, including that timestamp.
3. The approval message is sent to the computer.
4. The computer responds with the newest timestamp.
5. The transaction signing is initiated using the user verfied data together with the newest timestamp. This timestamp should be within 5 minutes from the initial one.
6. Once sigining is complete, the signatures are sent to the computer.

This is a video of the workflow https://www.youtube.com/watch?v=HK8jIogYgcI

For the computer side, I basically only modified https://github.com/iota-trezor/python-trezor to allow command line interaction. The goal is to integrate trezor support in upcoming IOTA wallets.