### PR TITLE
Generic hash support for Bitcoin transactions

### DIFF
--- a/firmware/Makefile
+++ b/firmware/Makefile
@@ -20,6 +20,7 @@ OBJS += protect.o
 OBJS += layout2.o
 OBJS += recovery.o
 OBJS += reset.o
+OBJS += hasher.o
 OBJS += signing.o
 OBJS += crypto.o
 OBJS += ethereum.o

--- a/firmware/coins-gen.py
+++ b/firmware/coins-gen.py
@@ -29,6 +29,7 @@ def get_fields(coin):
         '%d' % coin['forkid'] if coin['forkid'] else '0',
         '"%s"' % coin['bech32_prefix'] if coin.get('bech32_prefix') is not None else 'NULL',
         '0x%08x' % (0x80000000 + coin['bip44']),
+        'HASHER_SHA2',
     ]
 
 

--- a/firmware/coins.h
+++ b/firmware/coins.h
@@ -24,6 +24,7 @@
 #include <stdbool.h>
 
 #include "coins_count.h"
+#include "hasher.h"
 
 typedef struct _CoinInfo {
 	const char *coin_name;
@@ -43,6 +44,7 @@ typedef struct _CoinInfo {
 	uint32_t forkid;
 	const char *bech32_prefix;
 	uint32_t coin_type;
+	HasherType hasher_type;
 } CoinInfo;
 
 extern const CoinInfo coins[COINS_COUNT];

--- a/firmware/crypto.c
+++ b/firmware/crypto.c
@@ -54,21 +54,21 @@ uint32_t ser_length(uint32_t len, uint8_t *out)
 	return 5;
 }
 
-uint32_t ser_length_hash(SHA256_CTX *ctx, uint32_t len)
+uint32_t ser_length_hash(Hasher *hasher, uint32_t len)
 {
 	if (len < 253) {
-		sha256_Update(ctx, (const uint8_t *)&len, 1);
+		hasher_Update(hasher, (const uint8_t *)&len, 1);
 		return 1;
 	}
 	if (len < 0x10000) {
 		uint8_t d = 253;
-		sha256_Update(ctx, &d, 1);
-		sha256_Update(ctx, (const uint8_t *)&len, 2);
+		hasher_Update(hasher, &d, 1);
+		hasher_Update(hasher, (const uint8_t *)&len, 2);
 		return 3;
 	}
 	uint8_t d = 254;
-	sha256_Update(ctx, &d, 1);
-	sha256_Update(ctx, (const uint8_t *)&len, 4);
+	hasher_Update(hasher, &d, 1);
+	hasher_Update(hasher, (const uint8_t *)&len, 4);
 	return 5;
 }
 

--- a/firmware/crypto.h
+++ b/firmware/crypto.h
@@ -28,13 +28,14 @@
 #include <sha2.h>
 #include <pb.h>
 #include "coins.h"
+#include "hasher.h"
 #include "types.pb.h"
 
 #define ser_length_size(len) ((len) < 253 ? 1 : (len) < 0x10000 ? 3 : 5)
 
 uint32_t ser_length(uint32_t len, uint8_t *out);
 
-uint32_t ser_length_hash(SHA256_CTX *ctx, uint32_t len);
+uint32_t ser_length_hash(Hasher *hasher, uint32_t len);
 
 int sshMessageSign(HDNode *node, const uint8_t *message, size_t message_len, uint8_t *signature);
 

--- a/firmware/hasher.c
+++ b/firmware/hasher.c
@@ -1,0 +1,63 @@
+/*
+ * This file is part of the TREZOR project, https://trezor.io/
+ *
+ * Copyright (C) 2017 Saleem Rashid <trezor@saleemrashid.com>
+ *
+ * This library is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this library.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "hasher.h"
+
+void hasher_Init(Hasher *hasher, HasherType type) {
+	hasher->type = type;
+
+	switch (hasher->type) {
+	case HASHER_SHA2:
+		sha256_Init(&hasher->ctx.sha2);
+		break;
+	}
+}
+
+void hasher_Reset(Hasher *hasher) {
+	hasher_Init(hasher, hasher->type);
+}
+
+void hasher_Update(Hasher *hasher, const uint8_t *data, size_t length) {
+	switch (hasher->type) {
+	case HASHER_SHA2:
+		sha256_Update(&hasher->ctx.sha2, data, length);
+		break;
+	}
+}
+
+void hasher_Final(Hasher *hasher, uint8_t hash[HASHER_DIGEST_LENGTH]) {
+	switch (hasher->type) {
+	case HASHER_SHA2:
+		sha256_Final(&hasher->ctx.sha2, hash);
+		break;
+	}
+}
+
+void hasher_Double(Hasher *hasher, uint8_t hash[HASHER_DIGEST_LENGTH]) {
+	hasher_Final(hasher, hash);
+	hasher_Raw(hasher->type, hash, HASHER_DIGEST_LENGTH, hash);
+}
+
+void hasher_Raw(HasherType type, const uint8_t *data, size_t length, uint8_t hash[HASHER_DIGEST_LENGTH]) {
+	Hasher hasher;
+
+	hasher_Init(&hasher, type);
+	hasher_Update(&hasher, data, length);
+	hasher_Final(&hasher, hash);
+}

--- a/firmware/hasher.h
+++ b/firmware/hasher.h
@@ -1,0 +1,50 @@
+/*
+ * This file is part of the TREZOR project, https://trezor.io/
+ *
+ * Copyright (C) 2017 Saleem Rashid <trezor@saleemrashid.com>
+ *
+ * This library is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this library.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#ifndef __HASHER_H__
+#define __HASHER_H__
+
+#include <stddef.h>
+#include <stdint.h>
+
+#include "sha2.h"
+
+#define HASHER_DIGEST_LENGTH 32
+
+typedef enum {
+    HASHER_SHA2,
+} HasherType;
+
+typedef struct {
+    HasherType type;
+
+    union {
+        SHA256_CTX sha2;
+    } ctx;
+} Hasher;
+
+void hasher_Init(Hasher *hasher, HasherType type);
+void hasher_Reset(Hasher *hasher);
+void hasher_Update(Hasher *hasher, const uint8_t *data, size_t length);
+void hasher_Final(Hasher *hasher, uint8_t hash[HASHER_DIGEST_LENGTH]);
+void hasher_Double(Hasher *hasher, uint8_t hash[HASHER_DIGEST_LENGTH]);
+
+void hasher_Raw(HasherType type, const uint8_t *data, size_t length, uint8_t hash[HASHER_DIGEST_LENGTH]);
+
+#endif

--- a/firmware/signing.h
+++ b/firmware/signing.h
@@ -24,6 +24,7 @@
 #include <stdbool.h>
 #include "bip32.h"
 #include "coins.h"
+#include "hasher.h"
 #include "types.pb.h"
 
 void signing_init(uint32_t _inputs_count, uint32_t _outputs_count, const CoinInfo *_coin, const HDNode *_root, uint32_t _version, uint32_t _lock_time);

--- a/firmware/transaction.h
+++ b/firmware/transaction.h
@@ -25,6 +25,7 @@
 #include "sha2.h"
 #include "bip32.h"
 #include "coins.h"
+#include "hasher.h"
 #include "types.pb.h"
 
 typedef struct {
@@ -43,21 +44,21 @@ typedef struct {
 
 	uint32_t size;
 
-	SHA256_CTX ctx;
+	Hasher hasher;
 } TxStruct;
 
 bool compute_address(const CoinInfo *coin, InputScriptType script_type, const HDNode *node, bool has_multisig, const MultisigRedeemScriptType *multisig, char address[MAX_ADDR_SIZE]);
 uint32_t compile_script_sig(uint32_t address_type, const uint8_t *pubkeyhash, uint8_t *out);
 uint32_t compile_script_multisig(const MultisigRedeemScriptType *multisig, uint8_t *out);
-uint32_t compile_script_multisig_hash(const MultisigRedeemScriptType *multisig, uint8_t *hash);
+uint32_t compile_script_multisig_hash(const MultisigRedeemScriptType *multisig, HasherType hasher_type, uint8_t *hash);
 uint32_t serialize_script_sig(const uint8_t *signature, uint32_t signature_len, const uint8_t *pubkey, uint32_t pubkey_len, uint8_t sighash, uint8_t *out);
 uint32_t serialize_script_multisig(const MultisigRedeemScriptType *multisig, uint8_t sighash, uint8_t *out);
 int compile_output(const CoinInfo *coin, const HDNode *root, TxOutputType *in, TxOutputBinType *out, bool needs_confirm);
 
-uint32_t tx_prevout_hash(SHA256_CTX *ctx, const TxInputType *input);
-uint32_t tx_script_hash(SHA256_CTX *ctx, uint32_t size, const uint8_t *data);
-uint32_t tx_sequence_hash(SHA256_CTX *ctx, const TxInputType *input);
-uint32_t tx_output_hash(SHA256_CTX *ctx, const TxOutputBinType *output);
+uint32_t tx_prevout_hash(Hasher *hasher, const TxInputType *input);
+uint32_t tx_script_hash(Hasher *hasher, uint32_t size, const uint8_t *data);
+uint32_t tx_sequence_hash(Hasher *hasher, const TxInputType *input);
+uint32_t tx_output_hash(Hasher *hasher, const TxOutputBinType *output);
 uint32_t tx_serialize_script(uint32_t size, const uint8_t *data, uint8_t *out);
 
 uint32_t tx_serialize_footer(TxStruct *tx, uint8_t *out);


### PR DESCRIPTION
Rewrite Bitcoin transaction signing to support other hash algorithms. This is useful for coins like Decred, which uses BLAKE256 instead of SHA256.

The only remaining SHA256 specific code in the transaction signing is the `ecdsa_get_pubkeyhash` and `ecdsa_get_address_*` calls.

All device tests pass.

/cc @peterzen