### PR TITLE
Include file and line in Failure for DEBUG_LINK

### DIFF
--- a/firmware/fsm.c
+++ b/firmware/fsm.c
@@ -106,7 +106,11 @@ void fsm_sendSuccess(const char *text)
 	msg_write(MessageType_MessageType_Success, resp);
 }
 
+#if DEBUG_LINK
+void fsm_sendFailureDebug(FailureType code, const char *text, const char *source)
+#else
 void fsm_sendFailure(FailureType code, const char *text)
+#endif
 {
 	if (protectAbortedByInitialize) {
 		fsm_msgInitialize((Initialize *)0);
@@ -156,10 +160,18 @@ void fsm_sendFailure(FailureType code, const char *text)
 				break;
 		}
 	}
+#if DEBUG_LINK
+	resp->has_message = true;
+	strlcpy(resp->message, source, sizeof(resp->message));
+	if (text) {
+		strlcat(resp->message, text, sizeof(resp->message));
+	}
+#else
 	if (text) {
 		resp->has_message = true;
 		strlcpy(resp->message, text, sizeof(resp->message));
 	}
+#endif
 	msg_write(MessageType_MessageType_Failure, resp);
 }
 

--- a/firmware/fsm.h
+++ b/firmware/fsm.h
@@ -25,7 +25,14 @@
 // message functions
 
 void fsm_sendSuccess(const char *text);
+
+#if DEBUG_LINK
+void fsm_sendFailureDebug(FailureType code, const char *text, const char *source);
+
+#define fsm_sendFailure(code, text) fsm_sendFailureDebug((code), (text), __FILE__ ":" VERSTR(__LINE__) ":")
+#else
 void fsm_sendFailure(FailureType code, const char *text);
+#endif
 
 void fsm_msgInitialize(Initialize *msg);
 void fsm_msgGetFeatures(GetFeatures *msg);


### PR DESCRIPTION
This is especially useful for debugging the signing code (`Transaction has changed during signing` is not the most useful message!)

Should this be behind `DEBUG_LINK`? It shouldn't break anything (as the tests use the `FailureType`). If not behind `DEBUG_LINK`, we could add a `DEBUG_FSM` or similar flag (`DEBUG_LOG` is definitely not the right place for this)