### PR TITLE
Increase Features.coins max_count

### DIFF
--- a/firmware/protob/messages.options
+++ b/firmware/protob/messages.options
@@ -2,7 +2,7 @@ Features.vendor				max_size:33
 Features.device_id			max_size:25
 Features.language			max_size:17
 Features.label				max_size:33
-Features.coins				max_count:15
+Features.coins				max_count:16
 Features.revision			max_size:20
 Features.bootloader_hash		max_size:32
 Features.model				max_size:17


### PR DESCRIPTION
`vendor/trezor-common` was updated in 9732825e243548b20f9c617718333a6d359970b5 which breaks `DEBUG_LINK=1` builds because it includes `Decred Testnet`.