### PR TITLE
Enable MPU

### DIFF
--- a/firmware/trezor.c
+++ b/firmware/trezor.c
@@ -102,6 +102,11 @@ int main(void)
 	}
 #endif
 
+#ifdef APPVER
+	// enable MPU (Memory Protection Unit)
+	mpu_config();
+#endif
+
 	timer_init();
 
 #if DEBUG_LINK

--- a/setup.c
+++ b/setup.c
@@ -29,18 +29,20 @@
 
 uint32_t __stack_chk_guard;
 
-void __attribute__((noreturn)) __stack_chk_fail(void)
-{
-	layoutDialog(&bmp_icon_error, NULL, NULL, NULL, "Stack smashing", "detected.", NULL, "Please unplug", "the device.", NULL);
+static inline void __attribute__((noreturn)) fault_handler(const char *line1) {
+	layoutDialog(&bmp_icon_error, NULL, NULL, NULL, line1, "detected.", NULL, "Unplug your TREZOR", "contact our support.", NULL);
 	for (;;) {} // loop forever
+}
+
+void __attribute__((noreturn)) __stack_chk_fail(void) {
+	fault_handler("Stack smashing");
 }
 
 void nmi_handler(void)
 {
 	// Clock Security System triggered NMI
 	if ((RCC_CIR & RCC_CIR_CSSF) != 0) {
-		layoutDialog(&bmp_icon_error, NULL, NULL, NULL, "Clock instability", "detected.", NULL, "Please unplug", "the device.", NULL);
-		for (;;) {} // loop forever
+		fault_handler("Clock instability");
 	}
 }
 

--- a/setup.h
+++ b/setup.h
@@ -27,4 +27,6 @@ extern uint32_t __stack_chk_guard;
 void setup(void);
 void setupApp(void);
 
+void mpu_config(void);
+
 #endif


### PR DESCRIPTION
Disable code execution from SRAM and reconfiguration of the MPU.

Prevents almost all code execution attacks.