### PR TITLE
Switch to unprivileged execution and prevent access to MPU

### DIFF
--- a/firmware/trezor.c
+++ b/firmware/trezor.c
@@ -102,12 +102,12 @@ int main(void)
 	}
 #endif
 
+	timer_init();
+
 #ifdef APPVER
 	// enable MPU (Memory Protection Unit)
 	mpu_config();
 #endif
-
-	timer_init();
 
 #if DEBUG_LINK
 	oledSetDebugLink(1);

--- a/setup.c
+++ b/setup.c
@@ -193,4 +193,7 @@ void mpu_config(void)
 
 	__asm__ volatile("dsb");
 	__asm__ volatile("isb");
+
+	// Switch to unprivileged software execution to prevent access to MPU
+	set_mode_unprivileged();
 }

--- a/util.h
+++ b/util.h
@@ -66,6 +66,12 @@ static inline void __attribute__((noreturn)) load_vector_table(const vector_tabl
 	// Prevent compiler from generating stack protector code (which causes CPU fault because the stack is moved)
 	for (;;);
 }
+
+static inline void set_mode_unprivileged(void)
+{
+	// http://infocenter.arm.com/help/topic/com.arm.doc.dui0552a/CHDBIBGJ.html
+	__asm__ volatile("msr control, %0" :: "r" (0x1));
+}
 #endif
 
 #endif


### PR DESCRIPTION
All tests pass.

Attempts to write to the System Control Space cause a hard fault (perhaps there's a more specific fault handler we can enable for this?)