### PR TITLE
Fixing emulator makefile

### DIFF
--- a/Makefile.include
+++ b/Makefile.include
@@ -91,8 +91,8 @@ CFLAGS   += -DHEADLESS=1
 else
 CFLAGS   += -DHEADLESS=0
 
-CFLAGS   += $(shell pkg-config --cflags sdl2)
-LDLIBS   += $(shell pkg-config --libs sdl2)
+CFLAGS   += -I/usr/include/SDL2 -D_REENTRANT
+LDLIBS   += -lSDL2
 endif
 
 else

--- a/Makefile.include
+++ b/Makefile.include
@@ -78,6 +78,14 @@ LDFLAGS  += -L$(TOP_DIR) \
 ifeq ($(EMULATOR),1)
 CFLAGS   += -DEMULATOR=1
 
+CFLAGS   += -include $(TOP_DIR)emulator/emulator.h
+CFLAGS   += -include stdio.h
+
+LDFLAGS  += -L$(TOP_DIR)emulator
+
+LDLIBS   += -ltrezor -lemulator
+LIBDEPS  += $(TOP_DIR)/libtrezor.a $(TOP_DIR)emulator/libemulator.a
+
 ifeq ($(HEADLESS),1)
 CFLAGS   += -DHEADLESS=1
 else
@@ -87,13 +95,6 @@ CFLAGS   += $(shell pkg-config --cflags sdl2)
 LDLIBS   += $(shell pkg-config --libs sdl2)
 endif
 
-CFLAGS   += -include $(TOP_DIR)emulator/emulator.h
-CFLAGS   += -include stdio.h
-
-LDFLAGS  += -L$(TOP_DIR)emulator
-
-LDLIBS   += -ltrezor -lemulator
-LIBDEPS  += $(TOP_DIR)/libtrezor.a $(TOP_DIR)emulator/libemulator.a
 else
 ifdef APPVER
 CFLAGS   += -DAPPVER=$(APPVER)


### PR DESCRIPTION
Fixing makefile for non-headless emulator.

Taken from @jhoenicke PR here https://github.com/trezor/trezor-mcu/pull/295 (thx @saleemrashid for tip)

for some reason, git reversed which part of Makefile is actually moved :))