### PR TITLE
Add docker build script 

### DIFF
--- a/Dockerfile.emulator
+++ b/Dockerfile.emulator
@@ -1,0 +1,17 @@
+# initialize from the image
+
+FROM debian:9
+
+# install build tools and dependencies
+
+RUN dpkg --add-architecture i386 && \
+    apt-get update && \
+    apt-get install -y \
+    build-essential curl unzip git python3 python3-pip gcc-arm-none-eabi libnewlib-arm-none-eabi libsdl2-dev:i386 libsdl2-image-dev:i386 gcc-multilib
+
+ENV PROTOBUF_VERSION=3.4.0
+RUN curl -LO "https://github.com/google/protobuf/releases/download/v${PROTOBUF_VERSION}/protoc-${PROTOBUF_VERSION}-linux-x86_64.zip"
+RUN unzip "protoc-${PROTOBUF_VERSION}-linux-x86_64.zip" -d /usr
+RUN pip3 install "protobuf==${PROTOBUF_VERSION}" ecdsa
+
+RUN ln -s python3 /usr/bin/python

--- a/README.md
+++ b/README.md
@@ -13,6 +13,15 @@ https://trezor.io/
 
 This creates file `build/trezor-TAG.bin` and prints its fingerprint and size at the end of the build log.
 
+## How to build TREZOR emulator for Linux?
+
+1. [Install Docker](https://docs.docker.com/engine/installation/)
+2. `git clone https://github.com/trezor/trezor-mcu.git`
+3. `cd trezor-mcu`
+4. `./build-emulator.sh TAG` (where TAG is v1.5.0 for example, if left blank the script builds latest commit in master branch)
+
+This creates binary file `build/trezor-emulator-TAG`, which can be run and works as a trezor emulator. (Use `TREZOR_OLED_SCALE` env. variable to make screen bigger.)
+
 ## How to build TREZOR bootloader?
 
 1. [Install Docker](https://docs.docker.com/engine/installation/)

--- a/build-emulator.sh
+++ b/build-emulator.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+set -e
+
+IMAGE=trezor-mcu-build-emulator
+TAG=${1:-master}
+ELFFILE=build/trezor-emulator-$TAG
+
+docker build -f Dockerfile.emulator -t $IMAGE .
+docker run -t -v $(pwd)/build:/build:z $IMAGE /bin/sh -c "\
+	git clone https://github.com/trezor/trezor-mcu && \
+	cd trezor-mcu && \
+	git checkout $TAG && \
+	git submodule update --init && \
+	make -C vendor/libopencm3 && \
+	make -C vendor/nanopb/generator/proto && \
+	make -C firmware/protob && \
+	EMULATOR=1 make && \
+	EMULATOR=1 make -C emulator && \
+	EMULATOR=1 make -C firmware && \
+	cp firmware/trezor.elf /$ELFFILE"


### PR DESCRIPTION
I have added emulator build to docker.

Note that it requires changes from https://github.com/trezor/trezor-mcu/pull/301 

The readme mentions env variable from this PR https://github.com/trezor/trezor-mcu/pull/302