### PR TITLE
emulator: Removing useless build and install

### DIFF
--- a/Dockerfile.emulator
+++ b/Dockerfile.emulator
@@ -7,7 +7,7 @@ FROM debian:9
 RUN dpkg --add-architecture i386 && \
     apt-get update && \
     apt-get install -y \
-    build-essential curl unzip git python3 python3-pip gcc-arm-none-eabi libnewlib-arm-none-eabi \
+    build-essential curl unzip git python3 python3-pip \
     libsdl2-dev:i386 libsdl2-image-dev:i386 gcc-multilib
 
 ENV PROTOBUF_VERSION=3.4.0

--- a/build-emulator.sh
+++ b/build-emulator.sh
@@ -11,7 +11,6 @@ docker run -t -v $(pwd)/build:/build:z $IMAGE /bin/sh -c "\
 	cd trezor-mcu && \
 	git checkout $TAG && \
 	git submodule update --init && \
-	make -C vendor/libopencm3 && \
 	make -C vendor/nanopb/generator/proto && \
 	make -C firmware/protob && \
 	EMULATOR=1 make && \


### PR DESCRIPTION
As discussed in https://github.com/trezor/trezor-mcu/pull/303