### PR TITLE
nem: SignTx instead of ConfirmOutput in mosaic creation

### DIFF
--- a/firmware/nem2.c
+++ b/firmware/nem2.c
@@ -436,7 +436,7 @@ bool nem_askMosaicCreation(const NEMTransactionCommon *common, const NEMMosaicCr
 	}
 
 	layoutNEMNetworkFee(desc, true, _("Confirm creation fee"), mosaic_creation->fee, _("and network fee of"), common->fee);
-	if (!protectButton(ButtonRequestType_ButtonRequest_ConfirmOutput, false)) {
+	if (!protectButton(ButtonRequestType_ButtonRequest_SignTx, false)) {
 		return false;
 	}
 


### PR DESCRIPTION
See discussion https://github.com/trezor/trezor-mcu/commit/17e33d5517b0dd08c268d569b108a8c3484275de#r28307250

cc @saleemrashid 