### PR TITLE
Fix emulator build in docker

### DIFF
--- a/Dockerfile.emulator
+++ b/Dockerfile.emulator
@@ -4,11 +4,10 @@ FROM debian:9
 
 # install build tools and dependencies
 
-RUN dpkg --add-architecture i386 && \
-    apt-get update && \
+RUN apt-get update && \
     apt-get install -y \
     build-essential curl unzip git python3 python3-pip \
-    libsdl2-dev:i386 libsdl2-image-dev:i386 gcc-multilib
+    libsdl2-dev libsdl2-image-dev
 
 ENV PROTOBUF_VERSION=3.4.0
 RUN curl -LO "https://github.com/google/protobuf/releases/download/v${PROTOBUF_VERSION}/protoc-${PROTOBUF_VERSION}-linux-x86_64.zip"

--- a/build-emulator.sh
+++ b/build-emulator.sh
@@ -1,9 +1,9 @@
 #!/bin/bash
 set -e
 
-IMAGE=trezor-mcu-build-emulator
+IMAGE=trezor-mcu-build-emulator64
 TAG=${1:-master}
-ELFFILE=build/trezor-emulator-$TAG
+ELFFILE=build/trezor-emulator64-$TAG
 
 docker build -f Dockerfile.emulator -t $IMAGE .
 docker run -t -v $(pwd)/build:/build:z $IMAGE /bin/sh -c "\


### PR DESCRIPTION
Emulator is a 64-bit application now, so we should install 64-bit version of libSDL. Rename docker image and emulator filename to indicate 64-bitness as well.