### PR TITLE
nem: IV is not copied before encryption (moved to trezor-crypto)

### DIFF
--- a/firmware/nem2.c
+++ b/firmware/nem2.c
@@ -264,11 +264,8 @@ bool nem_fsmTransfer(nem_transaction_ctx *context, const HDNode *node, const NEM
 
 		random_buffer(encrypted, NEM_SALT_SIZE + AES_BLOCK_SIZE);
 
-		// hdnode_nem_encrypt mutates the IV
-		uint8_t iv[AES_BLOCK_SIZE];
-		memcpy(iv, &encrypted[NEM_SALT_SIZE], AES_BLOCK_SIZE);
-
 		const uint8_t *salt = encrypted;
+		const uint8_t *iv = &encrypted[NEM_SALT_SIZE];
 		uint8_t *buffer = &encrypted[NEM_SALT_SIZE + AES_BLOCK_SIZE];
 
 		bool ret = hdnode_nem_encrypt(node,


### PR DESCRIPTION
The IV copy was moved to trezor-crypto
(https://github.com/trezor/trezor-crypto/pull/140) so it is not needed
in trezor-mcu anymore