### PR TITLE
startup: shutdown at end instead of loop

### DIFF
--- a/startup.s
+++ b/startup.s
@@ -33,8 +33,8 @@ reset_handler:
   // enter the application code
   bl main
 
-  // loop forever if the application code returns
-  b .
+  // shutdown if the application code returns
+  b shutdown
 
   .global shutdown
   .type shutdown, STT_FUNC


### PR DESCRIPTION
In trezor-core we call shutdown when main returns. Let's do the same here.

One question: is the proposed patch OK, or it's better to let the code fall through? (because shutdown label is directly 4 lines below)