### PR TITLE
official trezor updates (#1)

### DIFF
--- a/Dockerfile.emulator
+++ b/Dockerfile.emulator
@@ -4,9 +4,11 @@ FROM debian:9
 
 # install build tools and dependencies
 
-RUN apt-get update && \
+RUN dpkg --add-architecture i386 && \
+    apt-get update && \
     apt-get install -y \
-    build-essential curl unzip git python3 python3-pip gcc-arm-none-eabi libnewlib-arm-none-eabi
+    build-essential curl unzip git python3 python3-pip \
+    libsdl2-dev:i386 libsdl2-image-dev:i386 gcc-multilib
 
 ENV PROTOBUF_VERSION=3.4.0
 RUN curl -LO "https://github.com/google/protobuf/releases/download/v${PROTOBUF_VERSION}/protoc-${PROTOBUF_VERSION}-linux-x86_64.zip"

--- a/Makefile.include
+++ b/Makefile.include
@@ -77,15 +77,6 @@ LDFLAGS  += -L$(TOP_DIR) \
 ifeq ($(EMULATOR),1)
 CFLAGS   += -DEMULATOR=1
 
-ifeq ($(HEADLESS),1)
-CFLAGS   += -DHEADLESS=1
-else
-CFLAGS   += -DHEADLESS=0
-
-CFLAGS   += $(shell pkg-config --cflags sdl2)
-LDLIBS   += $(shell pkg-config --libs sdl2)
-endif
-
 CFLAGS   += -include $(TOP_DIR)emulator/emulator.h
 CFLAGS   += -include stdio.h
 
@@ -93,6 +84,16 @@ LDFLAGS  += -L$(TOP_DIR)emulator
 
 LDLIBS   += -ltrezor -lemulator
 LIBDEPS  += $(TOP_DIR)/libtrezor.a $(TOP_DIR)emulator/libemulator.a
+
+ifeq ($(HEADLESS),1)
+CFLAGS   += -DHEADLESS=1
+else
+CFLAGS   += -DHEADLESS=0
+
+CFLAGS   += -I/usr/include/SDL2 -D_REENTRANT
+LDLIBS   += -lSDL2
+endif
+
 else
 ifdef APPVER
 CFLAGS   += -DAPPVER=$(APPVER)

--- a/README.md
+++ b/README.md
@@ -13,6 +13,15 @@ https://trezor.io/
 
 This creates file `build/trezor-TAG.bin` and prints its fingerprint and size at the end of the build log.
 
+## How to build TREZOR emulator for Linux?
+
+1. [Install Docker](https://docs.docker.com/engine/installation/)
+2. `git clone https://github.com/trezor/trezor-mcu.git`
+3. `cd trezor-mcu`
+4. `./build-emulator.sh TAG` (where TAG is v1.5.0 for example, if left blank the script builds latest commit in master branch)
+
+This creates binary file `build/trezor-emulator-TAG`, which can be run and works as a trezor emulator. (Use `TREZOR_OLED_SCALE` env. variable to make screen bigger.)
+
 ## How to build TREZOR bootloader?
 
 1. [Install Docker](https://docs.docker.com/engine/installation/)

--- a/build-emulator.sh
+++ b/build-emulator.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+set -e
+
+IMAGE=trezor-mcu-build-emulator
+TAG=${1:-master}
+ELFFILE=build/trezor-emulator-$TAG
+
+docker build -f Dockerfile.emulator -t $IMAGE .
+docker run -t -v $(pwd)/build:/build:z $IMAGE /bin/sh -c "\
+	git clone https://github.com/trezor/trezor-mcu && \
+	cd trezor-mcu && \
+	git checkout $TAG && \
+	git submodule update --init && \
+	make -C vendor/nanopb/generator/proto && \
+	make -C firmware/protob && \
+	EMULATOR=1 make && \
+	EMULATOR=1 make -C emulator && \
+	EMULATOR=1 make -C firmware && \
+	cp firmware/trezor.elf /$ELFFILE"


### PR DESCRIPTION
* emulator: Add TREZOR_OLED_SCALE variable

* emulator: Add instructions

* emulator: add docker build

* dockerfile: small typos to make them two Dockerfiles more similar

* emulator: fix Makefile

* emulator: use SDL2 directly

* emulator: Removing useless build and install