### PR TITLE
Recovery: Don't ask for confirmation on dry run.

### DIFF
--- a/firmware/fsm_msg_common.h
+++ b/firmware/fsm_msg_common.h
@@ -359,11 +359,13 @@ void fsm_msgRecoveryDevice(RecoveryDevice *msg)
 
 	CHECK_PARAM(!msg->has_word_count || msg->word_count == 12 || msg->word_count == 18 || msg->word_count == 24, _("Invalid word count"));
 
-	layoutDialogSwipe(&bmp_icon_question, _("Cancel"), _("Confirm"), NULL, _("Do you really want to"), _("recover the device?"), NULL, NULL, NULL, NULL);
-	if (!protectButton(ButtonRequestType_ButtonRequest_ProtectCall, false)) {
-		fsm_sendFailure(FailureType_Failure_ActionCancelled, NULL);
-		layoutHome();
-		return;
+	if (!dry_run) {
+		layoutDialogSwipe(&bmp_icon_question, _("Cancel"), _("Confirm"), NULL, _("Do you really want to"), _("recover the device?"), NULL, NULL, NULL, NULL);
+		if (!protectButton(ButtonRequestType_ButtonRequest_ProtectCall, false)) {
+			fsm_sendFailure(FailureType_Failure_ActionCancelled, NULL);
+			layoutHome();
+			return;
+		}
 	}
 
 	recovery_init(


### PR DESCRIPTION
The message is very confusing, as it is not recovering the device. Since dry-run recovery does not change anything, there is no need to ask for confirmation.
