### PR TITLE
Check if firmware has privileges.

### DIFF
--- a/firmware/bl_check.c
+++ b/firmware/bl_check.c
@@ -53,6 +53,10 @@ void check_bootloader(void)
 		shutdown();
 	}
 
+	if (is_mode_unprivileged()) {
+		return;
+	}
+
 	if (r == 32 && 0 == memcmp(hash, bl_hash, 32)) {
 		// all OK -> done
 		return;
@@ -61,6 +65,8 @@ void check_bootloader(void)
 	// ENABLE THIS AT YOUR OWN RISK
 	// ATTEMPTING TO OVERWRITE BOOTLOADER WITH UNSIGNED FIRMWARE MAY BRICK
 	// YOUR DEVICE.
+
+	layoutDialog(&bmp_icon_warning, NULL, NULL, NULL, "Overwriting bootloader", NULL, NULL, "DON'T UNPLUG", "YOUR TREZOR", NULL);
 
 	// unlock sectors
 	memory_write_unlock();

--- a/firmware/trezor.c
+++ b/firmware/trezor.c
@@ -96,12 +96,15 @@ int main(void)
 	__stack_chk_guard = random32(); // this supports compiler provided unpredictable stack protection checks
 #endif
 
-	timer_init();
+	if (!is_mode_unprivileged()) {
+
+		timer_init();
 
 #ifdef APPVER
-	// enable MPU (Memory Protection Unit)
-	mpu_config();
+		// enable MPU (Memory Protection Unit)
+		mpu_config();
 #endif
+	}
 
 #if DEBUG_LINK
 	oledSetDebugLink(1);

--- a/util.h
+++ b/util.h
@@ -79,6 +79,13 @@ static inline void set_mode_unprivileged(void)
 	// http://infocenter.arm.com/help/topic/com.arm.doc.dui0552a/CHDBIBGJ.html
 	__asm__ volatile("msr control, %0" :: "r" (0x1));
 }
+
+static inline bool is_mode_unprivileged(void)
+{
+	uint32_t r0;
+	__asm__ volatile("mrs %0, control" : "=r" (r0));
+	return r0 & 1;
+}
 #endif
 
 #endif


### PR DESCRIPTION
Only drop privileges if firmware is running with privileges.
Don't change the bootloader if running without privileges.

With this change the firmware can run without being signed.