### PR TITLE
Refactor Docker build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,7 +10,10 @@ RUN apt-get update && \
 
 ENV PROTOBUF_VERSION=3.4.0
 RUN curl -LO "https://github.com/google/protobuf/releases/download/v${PROTOBUF_VERSION}/protoc-${PROTOBUF_VERSION}-linux-x86_64.zip"
-RUN unzip "protoc-${PROTOBUF_VERSION}-linux-x86_64.zip" -d /usr
+
+# use zipfile module to extract files world-readable
+RUN python3 -m zipfile -e "protoc-${PROTOBUF_VERSION}-linux-x86_64.zip" /usr/local && chmod 755 /usr/local/bin/protoc
+
 RUN pip3 install "protobuf==${PROTOBUF_VERSION}" ecdsa
 
 RUN ln -s python3 /usr/bin/python

--- a/Makefile
+++ b/Makefile
@@ -24,9 +24,12 @@ OBJS += gen/bitmaps.o
 OBJS += gen/fonts.o
 
 libtrezor.a: $(OBJS)
-	$(AR) rcs libtrezor.a $(OBJS)
 
 include Makefile.include
+
+libtrezor.a:
+	@printf "  AR      $@\n"
+	$(Q)$(AR) rcs $@ $^
 
 .PHONY: vendor
 

--- a/Makefile.include
+++ b/Makefile.include
@@ -1,6 +1,10 @@
 TOP_DIR       := $(dir $(abspath $(lastword $(MAKEFILE_LIST))))
 TOOLCHAIN_DIR ?= $(TOP_DIR)vendor/libopencm3
 
+ifneq ($(V),1)
+Q := @
+endif
+
 PYTHON ?= python
 
 ifeq ($(EMULATOR),1)
@@ -152,34 +156,44 @@ release: $(NAME).bin
 	xxd -p $(NAME)-$(APPVER).bin | tr -d '\n' > $(NAME)-$(APPVER).bin.hex
 
 $(NAME).bin: $(NAME).elf
-	$(OBJCOPY) -Obinary $(NAME).elf $(NAME).bin
+	@printf "  OBJCOPY $@\n"
+	$(Q)$(OBJCOPY) -Obinary $(NAME).elf $(NAME).bin
 
 $(NAME).hex: $(NAME).elf
-	$(OBJCOPY) -Oihex $(NAME).elf $(NAME).hex
+	@printf "  OBJCOPY $@\n"
+	$(Q)$(OBJCOPY) -Oihex $(NAME).elf $(NAME).hex
 
 $(NAME).srec: $(NAME).elf
-	$(OBJCOPY) -Osrec $(NAME).elf $(NAME).srec
+	@printf "  OBJCOPY $@\n"
+	$(Q)$(OBJCOPY) -Osrec $(NAME).elf $(NAME).srec
 
 $(NAME).list: $(NAME).elf
-	$(OBJDUMP) -S $(NAME).elf > $(NAME).list
+	@printf "  OBJDUMP $@\n"
+	$(Q)$(OBJDUMP) -S $(NAME).elf > $(NAME).list
 
 $(NAME).elf: $(OBJS) $(LDSCRIPT) $(LIBDEPS)
-	$(LD) -o $(NAME).elf $(OBJS) $(LDLIBS) $(LDFLAGS)
+	@printf "  LD      $@\n"
+	$(Q)$(LD) -o $(NAME).elf $(OBJS) $(LDLIBS) $(LDFLAGS)
 
 %.o: %.s Makefile
-	$(AS) $(CPUFLAGS) -o $@ $<
+	@printf "  AS      $@\n"
+	$(Q)$(AS) $(CPUFLAGS) -o $@ $<
 
 %.o: %.c Makefile
-	$(CC) $(CFLAGS) -MMD -MP -o $@ -c $<
+	@printf "  CC      $@\n"
+	$(Q)$(CC) $(CFLAGS) -MMD -MP -o $@ -c $<
 
 %.small.o: %.c Makefile
-	$(CC) $(CFLAGS) -MMD -MP -o $@ -c $<
+	@printf "  CC      $@\n"
+	$(Q)$(CC) $(CFLAGS) -MMD -MP -o $@ -c $<
 
 %.d: %.c Makefile
-	@$(CC) $(CFLAGS) -MM -MP -MG -o $@ $<
+	@printf "  DEP     $@\n"
+	$(Q)$(CC) $(CFLAGS) -MM -MP -MG -o $@ $<
 
 %.small.d: %.c Makefile
-	@$(CC) $(CFLAGS) -MM -MP -MG -o $@ $<
+	@printf "  DEP     $@\n"
+	$(Q)$(CC) $(CFLAGS) -MM -MP -MG -o $@ $<
 
 clean::
 	rm -f $(OBJS)

--- a/build.sh
+++ b/build.sh
@@ -3,74 +3,9 @@ set -e
 
 IMAGE=trezor-mcu-build
 
-BOOTLOADER_TAG=${1:-master}
-FIRMWARE_TAG=${2:-master}
-REPOSITORY=${3:-trezor}
+BOOTLOADER_COMMIT=${1:-HEAD}
+FIRMWARE_COMMIT=${2:-HEAD}
 
-if [ "$REPOSITORY" = "local" ]; then
-	REPOSITORY=file:///local/
-else
-	REPOSITORY=https://github.com/$REPOSITORY/trezor-mcu.git
-fi
-
-BOOTLOADER_BINFILE=build/bootloader-$BOOTLOADER_TAG.bin
-BOOTLOADER_ELFFILE=build/bootloader-$BOOTLOADER_TAG.elf
-
-FIRMWARE_BINFILE=build/trezor-$FIRMWARE_TAG.bin
-FIRMWARE_ELFFILE=build/trezor-$FIRMWARE_TAG.elf
-
-docker build -t $IMAGE .
-
-echo
-echo "STARTING BUILD:"
-echo
-echo "Building bootloader '$BOOTLOADER_TAG' + firmware '$FIRMWARE_TAG' from repo: $REPOSITORY"
-echo
-
-docker run -i -t -v $(pwd):/local -v $(pwd)/build:/build:z $IMAGE /bin/sh -c "\
-	cd /tmp && \
-	git clone $REPOSITORY trezor-mcu-bl && \
-	cd trezor-mcu-bl && \
-	git checkout $BOOTLOADER_TAG && \
-	git submodule update --init --recursive && \
-	make -C vendor/libopencm3 && \
-	make && \
-	make -C bootloader align && \
-	cp bootloader/bootloader.bin /$BOOTLOADER_BINFILE && \
-	cp bootloader/bootloader.elf /$BOOTLOADER_ELFFILE && \
-	cd /tmp && \
-	git clone $REPOSITORY trezor-mcu-fw && \
-	cd trezor-mcu-fw && \
-	git checkout $FIRMWARE_TAG && \
-	git submodule update --init --recursive && \
-	make -C vendor/libopencm3 && \
-	make -C vendor/nanopb/generator/proto && \
-	make -C firmware/protob && \
-	make && \
-	cp /tmp/trezor-mcu-bl/bootloader/bootloader.bin bootloader/bootloader.bin
-	make -C firmware sign && \
-	cp firmware/trezor.bin /$FIRMWARE_BINFILE && \
-	cp firmware/trezor.elf /$FIRMWARE_ELFFILE
-	"
-
-echo
-echo "FINISHED BUILD"
-echo
-
-/usr/bin/env python -c "
-from __future__ import print_function
-import hashlib
-import sys
-for arg in sys.argv[1:]:
-  (fn, fprint_start, hashing, max_size) = arg.split(':')
-  fprint_start = int(fprint_start)
-  max_size = int(max_size)
-  data = open(fn, 'rb').read()
-  if hashing == 'd':
-      fprint = hashlib.sha256(hashlib.sha256(data[fprint_start:]).digest()).hexdigest()
-  else:
-      fprint = hashlib.sha256(data[fprint_start:]).hexdigest()
-  print('Filename    :', fn)
-  print('Fingerprint :', fprint)
-  print('Size        : %d bytes (out of %d maximum)' % (len(data), max_size))
-" $BOOTLOADER_BINFILE:0:d:32768 $FIRMWARE_BINFILE:256:s:491520
+docker build -t "$IMAGE" .
+docker run -it -v $(pwd):/src:z --user="$(stat -c "%u:%g" .)" "$IMAGE" \
+  /src/script/fullbuild "$BOOTLOADER_COMMIT" "$FIRMWARE_COMMIT"

--- a/firmware/Makefile
+++ b/firmware/Makefile
@@ -114,7 +114,8 @@ define GENERATE_CODE
 # $(3) - Additional output files
 
 $(1).h $(3): $(1).py $(2)
-	$(PYTHON) $(1).py
+	@printf "  PYTHON  $(1).py\n"
+	$(Q)$(PYTHON) $(1).py
 
 # Serialize build for parallel Make
 $(1).h: $(3)

--- a/firmware/protob/Makefile
+++ b/firmware/protob/Makefile
@@ -1,18 +1,26 @@
+ifneq ($(V),1)
+Q := @
+endif
+
 all: messages.pb.c types.pb.c messages_map.h
 
 PYTHON ?= python
 
 %.pb.c: %.pb %.options
-	$(PYTHON) ../../vendor/nanopb/generator/nanopb_generator.py $< -L '#include "%s"' -T
+	@printf "  NANOPB  $@\n"
+	$(Q)$(PYTHON) ../../vendor/nanopb/generator/nanopb_generator.py $< -L '#include "%s"' -T
 
 %.pb: %.proto
-	protoc -I/usr/include -I. $< -o $@
+	@printf "  PROTOC  $@\n"
+	$(Q)protoc -I/usr/include -I. $< -o $@
 
 %_pb2.py: %.proto
-	protoc -I/usr/include -I. $< --python_out=.
+	@printf "  PROTOC  $@\n"
+	$(Q)protoc -I/usr/include -I. $< --python_out=.
 
 messages_map.h: messages_map.py messages_pb2.py types_pb2.py
-	$(PYTHON) $< | grep -v -e MessageType_Lisk -e MessageType_Stellar > $@
+	@printf "  PYTHON  $<\n"
+	$(Q)$(PYTHON) $< | grep -v -e MessageType_Lisk -e MessageType_Stellar > $@
 
 clean:
 	rm -f *.pb *.o *.d *.pb.c *.pb.h *_pb2.py messages_map.h

--- a/script/cibuild
+++ b/script/cibuild
@@ -14,9 +14,11 @@ else
 fi
 
 make
+
 if [ "$EMULATOR" != 1 ]; then
-    make -C bootloader
+    make -C bootloader align
 fi
+
 make -C vendor/nanopb/generator/proto
 make -C firmware/protob
 

--- a/script/fingerprint
+++ b/script/fingerprint
@@ -1,0 +1,41 @@
+#!/usr/bin/env python
+from __future__ import print_function
+
+import binascii
+import hashlib
+
+
+def H(x):
+    return hashlib.sha256(x).digest()
+
+
+def compute_fingerprint(x, double):
+    digest = H(H(x)) if double else H(x)
+    return binascii.hexlify(digest).decode()
+
+
+if __name__ == "__main__":
+    import argparse
+
+    parser = argparse.ArgumentParser()
+
+    parser.add_argument("file", type=argparse.FileType("rb"),
+                        help="input file")
+    parser.add_argument("--offset", type=int, default=0,
+                        help="skip bytes at start of input")
+    parser.add_argument("--max-size", type=int,
+                        help="maximum input file size")
+    parser.add_argument("--double", action="store_true",
+                        help="use SHA-256d instead of SHA-256")
+
+    args = parser.parse_args()
+
+    data = args.file.read()
+    size = len(data)
+    fingerprint = compute_fingerprint(data[args.offset:], args.double)
+
+    print("Filename    :", args.file.name)
+    print("Fingerprint :", fingerprint)
+
+    print("Size        : {} bytes (out of {} maximum)"
+          .format(size, args.max_size))

--- a/script/fullbuild
+++ b/script/fullbuild
@@ -1,0 +1,93 @@
+#!/bin/bash
+
+# script/build: Build the TREZOR firmware in a clean working tree.
+#
+
+set -eu
+
+cd "$(dirname "$0")/.."
+
+readonly ARTIFACT_EXTENSIONS=(bin elf)
+readonly BUILD_DIR="$(readlink -f build)"
+
+readonly BOOTLOADER_DIR="$BUILD_DIR/bootloader"
+readonly BOOTLOADER_FILENAME="bootloader/bootloader.bin"
+readonly BOOTLOADER_PATH="$BOOTLOADER_DIR/$BOOTLOADER_FILENAME"
+
+readonly FIRMWARE_DIR="$BUILD_DIR/firmware"
+readonly FIRMWARE_FILENAME="firmware/trezor.bin"
+readonly FIRMWARE_PATH="$FIRMWARE_DIR/$FIRMWARE_FILENAME"
+
+worktree_setup() {
+    local path="$1"
+    local commit="$2"
+
+    rm -rf "$path"
+    git clone -n --reference=. . "$path" --recurse-submodules
+
+    # Use `git rev-parse` so that we can use any reference from the working repository.
+    git -C "$path" checkout "$(git rev-parse "$commit")"
+
+    ( cd "$path" && script/setup )
+}
+
+worktree_build() {
+    local path="$1"
+
+    ( cd "$path" && script/cibuild )
+}
+
+worktree_copy() {
+    local path="$1"
+    local filename="$2"
+    local pattern="$3"
+
+    local describe="$(git -C "$path" describe --tags --match "$pattern")"
+
+    local src="$path/$filename"
+
+    local basename="$(basename "$filename")"
+    local dest="$BUILD_DIR/${basename%.*}-$describe.${basename##*.}"
+
+    for extension in "${ARTIFACT_EXTENSIONS[@]}"; do
+	install -Dm0644 \
+	    "${src%.*}.$extension" \
+	    "${dest%.*}.$extension"
+    done
+
+    printf "%s" "$dest"
+}
+
+main() {
+    local bootloader_commit="$1"
+    local firmware_commit="$2"
+
+    worktree_setup "$BOOTLOADER_DIR" "$bootloader_commit"
+    worktree_build "$BOOTLOADER_DIR"
+
+    local bootloader_path="$(worktree_copy \
+	"$BOOTLOADER_DIR" \
+	"$BOOTLOADER_FILENAME" \
+	"bl*")"
+
+    worktree_setup "$FIRMWARE_DIR" "$firmware_commit"
+    cp "$BOOTLOADER_PATH" "$FIRMWARE_DIR/$BOOTLOADER_FILENAME"
+    worktree_build "$FIRMWARE_DIR"
+
+    local firmware_path="$(worktree_copy \
+	"$FIRMWARE_DIR" \
+	"$FIRMWARE_FILENAME" \
+	"v*")"
+
+    printf "\n\n"; script/fingerprint \
+	"$bootloader_path" \
+	--max-size 32768 \
+	--double
+
+    printf "\n\n"; script/fingerprint \
+	"$firmware_path" \
+	--offset 256 \
+	--max-size 491520
+}
+
+main "$@"

--- a/script/toolchain-download
+++ b/script/toolchain-download
@@ -1,0 +1,54 @@
+#!/bin/bash
+
+# script/toolchain-download: Download and extract the GNU Arm Embedded toolchain
+#			     for building the TREZOR firmware.
+
+set -e
+
+cd "$(dirname "$0")/../vendor"
+
+readonly URL="https://launchpad.net/gcc-arm-embedded/5.0/5-2016-q2-update/+download/gcc-arm-none-eabi-5_4-2016q2-20160622-linux.tar.bz2"
+readonly SHA256SUM="9910b6b5df12efe564dbb3856bf1599d4c16178a6f28bd8a23c9e5c3edc219e4"
+
+readonly FILENAME="$(basename "$URL")"
+readonly DIRECTORY="gcc-arm-none-eabi-5_4-2016q2"
+
+if [ "$(uname)" != "Linux" ]; then
+    printf "Unsupported platform\n" >&2
+    exit 1
+fi
+
+validate_download() {
+    printf "$SHA256SUM $FILENAME" | sha256sum -c
+}
+
+download_file() {
+    curl -LC- "$URL" -o "$FILENAME"
+}
+
+extract_download() {
+    local temporary_dir="$(mktemp -d ./toolchain.XXXXXXXXXX)"
+    trap "rm -rf $temporary_dir" EXIT
+
+    tar -xf "$FILENAME" -C "$temporary_dir"
+    mv "$temporary_dir/$DIRECTORY" .
+    rm -f "$FILENAME"
+}
+
+if [ ! -d "$DIRECTORY" ]; then
+    if ! validate_download; then
+	download_file
+	validate_download
+    fi
+
+    extract_download
+fi
+
+# init toolchain as repository so Git will skip it
+git init -q "$DIRECTORY"
+
+# update toolchain symlink
+ln -snf "$DIRECTORY" toolchain
+
+# sanity-check extracted toolchain
+toolchain/bin/arm-none-eabi-gcc --version >/dev/null

--- a/script/toolchain-run
+++ b/script/toolchain-run
@@ -1,0 +1,18 @@
+#!/bin/bash
+
+# script/toolchain-run: Run command with downloaded GNU Arm Embedded toolchain.
+#
+
+set -e
+
+readonly TOOLCHAIN_RELATIVE_DIR="vendor/toolchain"
+readonly TOOLCHAIN_DIR="$(readlink -f "$(dirname "$0")/../$TOOLCHAIN_RELATIVE_DIR")"
+
+if [ ! -d "$TOOLCHAIN_DIR" ]; then
+    printf "Could not find toolchain in %s.\n" "$TOOLCHAIN_RELATIVE_DIR" >&2
+    printf "Run script/toolchain-download to download it.\n" >&2
+    exit 1
+fi
+
+export PATH="$TOOLCHAIN_DIR/bin:$PATH"
+exec "$@"

--- a/vendor/.gitignore
+++ b/vendor/.gitignore
@@ -1,0 +1,4 @@
+# toolchain-download
+gcc-arm-none-eabi-*
+toolchain
+toolchain.*/


### PR DESCRIPTION
 Refactor Docker build to use `script/fullbuild <bootloader_commit> <firmware_commit>`, which builds in `build/{bootloader,firmware}`, copying artifacts to `build/bootloader-bl*.{bin,elf}` and `build/firmware-v*.{bin,elf}`.

Because this script uses `git rev-parse` internally, you can do tricks like `./build.sh origin/bootloader-fix upstream/firmware-wip` (as a replacement for the `REPOSITORY` parameter). Then, `git describe` will still format a nice artifact filename.

Also, the Docker build will now drop privileges to UID/GID of the source repository, so there aren't random `root`-owned files lying around in the repository.

Rewrite firmware fingerprint script from `build.sh` to `script/fingerprint`.

Haven't touched the emulator Docker build. Do we actually need this? AFAICT, it builds the emulator with dynamic linking, so it isn't particularly useful. cc @karel-3d

Fixes #373 