### PR TITLE
fullbuild: Call script/bootstrap before clone

### DIFF
--- a/script/fullbuild
+++ b/script/fullbuild
@@ -62,6 +62,8 @@ main() {
     local bootloader_commit="$1"
     local firmware_commit="$2"
 
+    script/bootstrap
+
     worktree_setup "$BOOTLOADER_DIR" "$bootloader_commit"
     worktree_build "$BOOTLOADER_DIR"
 


### PR DESCRIPTION
`fullbuild` would previously fail if the parent repository hadn't initialized submodules yet, due to the use of `--reference`

06fbb91 fixes another issue (the use of nested submodules), but didn't fully fix this one.

Fixes #382