### PR TITLE
support full 32bit chain_id, cast (uint64_t)v

### DIFF
--- a/firmware/ethereum.c
+++ b/firmware/ethereum.c
@@ -36,9 +36,6 @@
 #include "memzero.h"
 #include "messages.pb.h"
 
-/* maximum supported chain id.  v must fit in an uint32_t. */
-#define MAX_CHAIN_ID 2147483630
-
 static bool ethereum_signing = false;
 static uint32_t data_total, data_left;
 static EthereumTxRequest msg_tx_request;
@@ -203,7 +200,7 @@ static void send_signature(void)
 
 	msg_tx_request.has_signature_v = true;
 	if (chain_id) {
-		msg_tx_request.signature_v = v + 2 * chain_id + 35;
+		msg_tx_request.signature_v = (uint64_t)v + 2 * chain_id + 35;
 	} else {
 		msg_tx_request.signature_v = v + 27;
 	}
@@ -461,7 +458,7 @@ void ethereum_signing_init(EthereumSignTx *msg, const HDNode *node)
 
 	/* eip-155 chain id */
 	if (msg->has_chain_id) {
-		if (msg->chain_id < 1 || msg->chain_id > MAX_CHAIN_ID) {
+		if (msg->chain_id < 1) {
 			fsm_sendFailure(Failure_FailureType_Failure_DataError, _("Chain Id out of bounds"));
 			ethereum_signing_abort();
 			return;


### PR DESCRIPTION
with the following PR https://github.com/trezor/trezor-common/pull/174 (64bit `signature_v`)
`r,s` value can be calculated successfully.

I'm not sure why `v` value is truncated to 32bit. but anyway,
r,s values are correctly obtained.

simply recalculate `v` value in the javascript level, signing could be done successfully with full ranged 32bit chain_id.

