### PR TITLE
ethereum: support full range 32bit chain_id

### DIFF
--- a/firmware/ethereum.c
+++ b/firmware/ethereum.c
@@ -202,7 +202,9 @@ static void send_signature(void)
 	msg_tx_request.has_data_length = false;
 
 	msg_tx_request.has_signature_v = true;
-	if (chain_id) {
+	if (chain_id > MAX_CHAIN_ID) {
+		msg_tx_request.signature_v = v;
+	} else if (chain_id) {
 		msg_tx_request.signature_v = v + 2 * chain_id + 35;
 	} else {
 		msg_tx_request.signature_v = v + 27;
@@ -464,7 +466,7 @@ void ethereum_signing_init(EthereumSignTx *msg, const HDNode *node)
 
 	/* eip-155 chain id */
 	if (msg->has_chain_id) {
-		if (msg->chain_id < 1 || msg->chain_id > MAX_CHAIN_ID) {
+		if (msg->chain_id < 1) {
 			fsm_sendFailure(Failure_FailureType_Failure_DataError, _("Chain Id out of bounds"));
 			ethereum_signing_abort();
 			return;


### PR DESCRIPTION
 * remove chain_id restriction to support full 32bit chain_id.
 * for `chain_id > MAX_CHAIN_ID(2147483630)` case, simply return `v` signature parity.

with this fix Trezor can support full 32bit chain_id.
- *no backward compatible issue.*
- for chain_id > MAX_CHAIN_ID case, returned `v` is `0` or `1` and it can be easily detectable.
- for chain_id > MAX_CHAIN_ID case, one can easily recalculate `signature_v` at client side.

`chain_id` |`signature_v` | firmware| `v`
-----------|---------|-----------|----------------
no EIP155 case | `27`+ `v` (>= `27`) | `1.6.2`  | `1`, `0`
`1` <= `chain_id` <= `MAX_CHAIN_ID`      | 2 * `chain_id` + 35 + `v` (>= `37`) | `1.6.2`[*] [**]  | `1`, `0`
`chain_id` > `MAX_CHAIN_ID` | `v` ( <= `1`) | *detectable* | `1`, `0`

[*]: currently, official 1.6.2 firmware only support `0 < chain_id < 256` correctly.
[**]: `trezor:master` repo support `0 < chain_id <= MAX_CHAIN_ID`.
