### PR TITLE
Add support for AtheiosChain (ATH)

### DIFF
--- a/firmware/ethereum.c
+++ b/firmware/ethereum.c
@@ -263,6 +263,7 @@ static void ethereumFormatAmount(const bignum256 *amnt, const TokenType *token, 
 				case   62: suffix = " tETC"; break;  // Ethereum Classic Testnet
 				case   64: suffix = " ELLA"; break;  // Ellaism
 				case  820: suffix = " CLO";  break;  // Callisto
+				case 1620: suffix = " ATH";  break;  // Atheios
 				case 1987: suffix = " EGEM"; break;  // EtherGem
 				case 31102: suffix = " ESN"; break;  // Ethersocial Network
 				case 200625: suffix = " AKA"; break; // Akroma


### PR DESCRIPTION
EIP-155 is now properly working with Atheios!! Tested personally on the Ledger Nano S

homepage           : https://atheios.com
block explorer     : http://explorer.atheios.com | https://scan.atheios.com
network statistics : http://stats.atheios.com
slip0044 index     : 1620
chainId            : 1620

depends-on: https://github.com/trezor/trezor-common/pull/195

cc: @atheioschain