### PR TITLE
build: Use new Debian in docker for py3.6

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 # initialize from the image
 
-FROM debian:9
+FROM debian:buster
 
 # install build tools and dependencies
 


### PR DESCRIPTION
Current stable Debian uses 3.4, we use f-strings in token definitions.

Fixes https://github.com/trezor/trezor-mcu/issues/409