### PR TITLE
build: Use pipenv in docker build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,6 +14,7 @@ RUN curl -LO "https://github.com/google/protobuf/releases/download/v${PROTOBUF_V
 # use zipfile module to extract files world-readable
 RUN python3 -m zipfile -e "protoc-${PROTOBUF_VERSION}-linux-x86_64.zip" /usr/local && chmod 755 /usr/local/bin/protoc
 
-RUN pip3 install "protobuf==${PROTOBUF_VERSION}" ecdsa
+RUN pip3 install pipenv
+
 
 RUN ln -s python3 /usr/bin/python

--- a/script/fullbuild
+++ b/script/fullbuild
@@ -3,6 +3,10 @@
 # script/build: Build the TREZOR firmware in a clean working tree.
 #
 
+# this needs to be there, otherwise python click installer vomits an error
+export LC_ALL=C.UTF-8
+export LANG=C.UTF-8
+
 set -eu
 
 cd "$(dirname "$0")/.."
@@ -34,7 +38,7 @@ worktree_setup() {
 worktree_build() {
     local path="$1"
 
-    ( cd "$path" && script/cibuild )
+    ( cd "$path" && pipenv install && pipenv run script/cibuild )
 }
 
 worktree_copy() {


### PR DESCRIPTION
Fixes https://github.com/trezor/trezor-mcu/issues/410

With https://github.com/trezor/trezor-mcu/pull/411 , the docker build now works.