### PR TITLE
emulator: make buildable on macOS

### DIFF
--- a/emulator/strl.c
+++ b/emulator/strl.c
@@ -22,6 +22,7 @@
 
 #include <string.h>
 
+#if (!defined __APPLE__) && (!defined HAVE_STRLCPY)
 size_t strlcpy(char *dst, const char *src, size_t size) {
 	size_t ret = strlen(src);
 
@@ -39,3 +40,5 @@ size_t strlcat(char *dst, const char *src, size_t size) {
 
 	return n + strlcpy(&dst[n], src, size - n);
 }
+
+#endif

--- a/emulator/strl.h
+++ b/emulator/strl.h
@@ -22,7 +22,9 @@
 
 #include <stddef.h>
 
+#if (!defined __APPLE__) && (!defined HAVE_STRLCPY)
 size_t strlcpy(char *dst, const char *src, size_t size);
 size_t strlcat(char *dst, const char *src, size_t size);
+#endif
 
 #endif


### PR DESCRIPTION
Emulator doesn't build on macOS because macOS already has `strlcpy` and `strlcat`.