### PR TITLE
Add sha256sum check to protobuf binaries in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -17,7 +17,9 @@ RUN if [ "$EMULATOR" = 1 ]; then \
     fi
 
 ENV PROTOBUF_VERSION=3.4.0
+ENV PROTOBUF_HASH=e4b51de1b75813e62d6ecdde582efa798586e09b5beaebfb866ae7c9eaadace4
 RUN curl -LO "https://github.com/google/protobuf/releases/download/v${PROTOBUF_VERSION}/protoc-${PROTOBUF_VERSION}-linux-x86_64.zip"
+RUN echo "${PROTOBUF_HASH} protoc-${PROTOBUF_VERSION}-linux-x86_64.zip" | sha256sum -c
 
 ENV PYTHON=python3
 ENV LC_ALL=C.UTF-8


### PR DESCRIPTION
The docker build fails if the hash is incorrect.