### PR TITLE
Secure mnemonic checking

### DIFF
--- a/firmware/fsm_msg_common.h
+++ b/firmware/fsm_msg_common.h
@@ -339,7 +339,7 @@ void fsm_msgApplyFlags(const ApplyFlags *msg)
 
 void fsm_msgRecoveryDevice(const RecoveryDevice *msg)
 {
-    CHECK_PIN
+	CHECK_PIN_UNCACHED
 
 	const bool dry_run = msg->has_dry_run ? msg->dry_run : false;
 	if (!dry_run) {


### PR DESCRIPTION
config: Check mnemonic by comparing hashes instead of the actual mnemonics, to mitigate side-channel attacks.