### PR TITLE
Set Bitcoin PublicKey's node to optional

### DIFF
--- a/firmware/fsm_msg_coin.h
+++ b/firmware/fsm_msg_coin.h
@@ -48,6 +48,7 @@ void fsm_msgGetPublicKey(const GetPublicKey *msg)
 		}
 	}
 
+	resp->has_node = true;
 	resp->node.depth = node->depth;
 	resp->node.fingerprint = fingerprint;
 	resp->node.child_num = node->child_num;

--- a/firmware/protob/Makefile
+++ b/firmware/protob/Makefile
@@ -26,7 +26,7 @@ messages_%_pb2.py: messages-%.proto
 	$(Q)protoc -I/usr/include -I. $< --python_out=.
 
 messages_map.h messages_map_limits.h: messages_map.py messages_pb2.py
-	$(Q)$(PYTHON) $< Cardano Tezos Ripple Monero DebugMonero Ontology Tron Eos
+	$(Q)$(PYTHON) $< Cardano Tezos Ripple Monero DebugMonero Ontology Tron Eos Binance
 
 clean:
 	rm -f *.pb *.o *.d *.pb.c *.pb.h *_pb2.py messages_map.h messages_map_limits.h


### PR DESCRIPTION
To make it identical to other coins and avoid bugs such as https://github.com/trezor/trezor-mcu/commit/f40219dbb609ed468aa74db25d1295fed826e547