### PR TITLE
Add support for creating Stakenet TPoS contracts

### DIFF
--- a/firmware/crypto.c
+++ b/firmware/crypto.c
@@ -33,6 +33,8 @@
 #include "segwit_addr.h"
 #include "cash_addr.h"
 
+#define SERIALIZE_TX_INPUT 36
+
 uint32_t ser_length(uint32_t len, uint8_t *out)
 {
 	if (len < 253) {
@@ -126,6 +128,108 @@ int cryptoMessageSign(const CoinInfo *coin, HDNode *node, InputScriptType script
 {
 	uint8_t hash[HASHER_DIGEST_LENGTH];
 	cryptoMessageHash(coin, message, message_len, hash);
+
+	uint8_t pby;
+	int result = hdnode_sign_digest(node, hash, signature + 1, &pby, NULL);
+	if (result == 0) {
+		switch (script_type) {
+			case InputScriptType_SPENDP2SHWITNESS:
+				// segwit-in-p2sh
+				signature[0] = 35 + pby;
+				break;
+			case InputScriptType_SPENDWITNESS:
+				// segwit
+				signature[0] = 39 + pby;
+				break;
+			default:
+				// p2pkh
+				signature[0] = 31 + pby;
+				break;
+		}
+	}
+	return result;
+}
+
+static void cryptoMessageHashWithoutHeader(const CoinInfo *coin, const uint8_t *message, size_t message_len, uint8_t hash[HASHER_DIGEST_LENGTH])
+{
+	Hasher hasher;
+	hasher_Init(&hasher, coin->curve->hasher_sign);
+	hasher_Update(&hasher, message, message_len);
+	hasher_Final(&hasher, hash);
+}
+
+signed char getHexDigit(char c)
+{
+    unsigned char uc = c;
+    if (uc >= '0' && uc <= '9') {
+		return uc - '0';
+	}
+        
+    if (uc >= 'A' && uc <= 'F') {
+		return uc - 'A' + 10;
+	}
+
+    if (uc >= 'a' && uc <= 'f') {
+		return uc - 'a' + 10;
+	}
+
+    return -1;
+}
+
+void serializeTxInput(const uint8_t* psz, const uint32_t nout, uint8_t* data)
+{
+    memset(data, 0, SERIALIZE_TX_INPUT);
+
+    const uint8_t* pbegin = psz;
+    while (getHexDigit(*psz) != -1) {
+		psz++;
+	}
+
+	psz--;
+    uint8_t* p1 = data;
+    unsigned char* pend = p1 + SERIALIZE_TX_INPUT - sizeof(nout);
+    while (psz >= pbegin && p1 < pend) {
+        *p1 = getHexDigit(*psz--);
+        if (psz >= pbegin) {
+            *p1 |= ((uint8_t)getHexDigit(*psz--) << 4);
+            p1++;
+        }
+    }
+
+    char* ptrnout = (char*)&nout;
+    for (uint8_t i = 0; i < sizeof(nout); i++) {
+        *p1 = *(ptrnout + i);
+        p1++;
+    }
+}
+
+int getNOutByTxInput(const uint8_t* txinput, size_t txinput_len)
+{
+	size_t i = 0;
+	for (i = 0; i < txinput_len; i++) {
+		if (*(txinput + i) == ':') {
+			break;
+		}
+	}
+
+	uint32_t nout = 0;
+	for (uint8_t j = i + 1; j < txinput_len; j++) {
+		nout *= 10;
+		nout += *(txinput + j) - '0';
+	}
+
+	return nout;
+}
+
+int cryptoTxInputSign(const CoinInfo *coin, HDNode *node, InputScriptType script_type, const uint8_t* txinput, size_t txinput_len, uint8_t *signature)
+{
+	uint8_t hash[HASHER_DIGEST_LENGTH];
+	uint8_t serialized_txinput[SERIALIZE_TX_INPUT];
+
+	uint32_t nout = getNOutByTxInput(txinput, txinput_len);
+	serializeTxInput(txinput, nout, serialized_txinput);
+	
+	cryptoMessageHashWithoutHeader(coin, serialized_txinput, SERIALIZE_TX_INPUT, hash);
 
 	uint8_t pby;
 	int result = hdnode_sign_digest(node, hash, signature + 1, &pby, NULL);

--- a/firmware/crypto.h
+++ b/firmware/crypto.h
@@ -44,6 +44,8 @@ int gpgMessageSign(HDNode *node, const uint8_t *message, size_t message_len, uin
 
 int cryptoMessageSign(const CoinInfo *coin, HDNode *node, InputScriptType script_type, const uint8_t *message, size_t message_len, uint8_t *signature);
 
+int cryptoTxInputSign(const CoinInfo *coin, HDNode *node, InputScriptType script_type, const uint8_t* txinput, size_t txinput_lenm, uint8_t *signature);
+
 int cryptoMessageVerify(const CoinInfo *coin, const uint8_t *message, size_t message_len, const char *address, const uint8_t *signature);
 
 /* ECIES disabled

--- a/firmware/fsm.h
+++ b/firmware/fsm.h
@@ -69,6 +69,7 @@ void fsm_msgGetPublicKey(const GetPublicKey *msg);
 void fsm_msgSignTx(const SignTx *msg);
 void fsm_msgTxAck(TxAck *msg);    // not const because we mutate input/output scripts
 void fsm_msgGetAddress(const GetAddress *msg);
+void fsm_msgSignTxInput(const SignTxInput *msg);
 void fsm_msgSignMessage(const SignMessage *msg);
 void fsm_msgVerifyMessage(const VerifyMessage *msg);
 

--- a/firmware/protob/messages-bitcoin.options
+++ b/firmware/protob/messages-bitcoin.options
@@ -15,6 +15,10 @@ SignMessage.address_n                                       max_count:8
 SignMessage.message                                         max_size:1024
 SignMessage.coin_name                                       max_size:21
 
+SignTxInput.address_n                                       max_count:8
+SignTxInput.tx_input                                        max_size:1024
+SignTxInput.coin_name                                       max_size:21
+
 VerifyMessage.address                                       max_size:130
 VerifyMessage.signature                                     max_size:65
 VerifyMessage.message                                       max_size:1024

--- a/firmware/protob/messages-bitcoin.options
+++ b/firmware/protob/messages-bitcoin.options
@@ -39,7 +39,7 @@ TxInputType.prev_block_hash_bip115                          max_size:32
 
 TxOutputType.address                                        max_size:130
 TxOutputType.address_n                                      max_count:8
-TxOutputType.op_return_data                                 max_size:80
+TxOutputType.op_return_data                                 max_size:400
 TxOutputType.block_hash_bip115                              max_size:32
 
 TxOutputBinType.script_pubkey                               max_size:520

--- a/firmware/transaction.c
+++ b/firmware/transaction.c
@@ -212,9 +212,32 @@ int compile_output(const CoinInfo *coin, const HDNode *root, TxOutputType *in, T
 		}
 		uint32_t r = 0;
 		out->script_pubkey.bytes[0] = 0x6A; r++; // OP_RETURN
-		r += op_push(in->op_return_data.size, out->script_pubkey.bytes + r);
-		memcpy(out->script_pubkey.bytes + r, in->op_return_data.bytes, in->op_return_data.size); r += in->op_return_data.size;
-		out->script_pubkey.size = r;
+		// TPOS contract for Stakenet
+		if (strcmp(coin->coin_name, "Stakenet") == 0 && in->op_return_data.size == 0x86) {
+			
+			r += op_push(0x22, out->script_pubkey.bytes + r);
+			memcpy(out->script_pubkey.bytes + r, in->op_return_data.bytes, 0x22);
+			r += 0x22;
+
+			r += op_push(0x22, out->script_pubkey.bytes + r);
+			memcpy(out->script_pubkey.bytes + r, in->op_return_data.bytes + 0x22, 0x22);
+			r += 0x22;
+
+			r += op_push(0x1, out->script_pubkey.bytes + r);
+			memcpy(out->script_pubkey.bytes + r, in->op_return_data.bytes + 0x44, 0x1);
+			r += 0x1;
+
+			r += op_push(0x41, out->script_pubkey.bytes + r);
+			memcpy(out->script_pubkey.bytes + r, in->op_return_data.bytes + 0x45, 0x41);
+			r += 0x41;
+
+			out->script_pubkey.size = r;
+		} else {
+			r += op_push(in->op_return_data.size, out->script_pubkey.bytes + r);
+			memcpy(out->script_pubkey.bytes + r, in->op_return_data.bytes, in->op_return_data.size); r += in->op_return_data.size;
+			out->script_pubkey.size = r;
+		}
+
 		return r;
 	}
 


### PR DESCRIPTION
Adds support for handling the `SignTxInput` message, which takes an input (with the `txid:index` format) and signs it using the given address.

The serialization format for the input is equivalent to how bitcoin serializes the `COutPoint` class.

This requires the changes from [trezor-common](https://github.com/trezor/trezor-common/pull/292).