### PR TITLE
Return mnemonic as bytes

### DIFF
--- a/firmware/config.c
+++ b/firmware/config.c
@@ -172,6 +172,18 @@ static secbool config_get_bool(uint16_t key, bool *value)
     }
 }
 
+static secbool config_get_bytes(uint16_t key, uint8_t *dest, uint16_t dest_size, uint16_t *real_size)
+{
+    if (dest_size == 0) {
+        return secfalse;
+    }
+
+    if (sectrue != storage_get(key, dest, dest_size, real_size)) {
+        return secfalse;
+    }
+    return sectrue;
+}
+
 static secbool config_get_string(uint16_t key, char *dest, uint16_t dest_size)
 {
     if (dest_size == 0) {
@@ -686,6 +698,11 @@ bool config_setMnemonic(const char *mnemonic)
     config_set_bool(KEY_INITIALIZED, true);
 
     return true;
+}
+
+bool config_getMnemonicBytes(uint8_t *dest, uint16_t dest_size, uint16_t *real_size)
+{
+    return sectrue == config_get_bytes(KEY_MNEMONIC, dest, dest_size, real_size);
 }
 
 bool config_getMnemonic(char *dest, uint16_t dest_size)

--- a/firmware/config.h
+++ b/firmware/config.h
@@ -114,6 +114,7 @@ bool session_getState(const uint8_t *salt, uint8_t *state, const char *passphras
 bool config_setMnemonic(const char *mnemonic);
 bool config_containsMnemonic(const char *mnemonic);
 bool config_getMnemonic(char *dest, uint16_t dest_size);
+bool config_getMnemonicBytes(uint8_t *dest, uint16_t dest_size, uint16_t *real_size);
 
 #if DEBUG_LINK
 bool config_dumpNode(HDNodeType *node);

--- a/firmware/fsm_msg_coin.h
+++ b/firmware/fsm_msg_coin.h
@@ -48,6 +48,7 @@ void fsm_msgGetPublicKey(const GetPublicKey *msg)
 		}
 	}
 
+	resp->has_node = true;
 	resp->node.depth = node->depth;
 	resp->node.fingerprint = fingerprint;
 	resp->node.child_num = node->child_num;
@@ -61,8 +62,8 @@ void fsm_msgGetPublicKey(const GetPublicKey *msg)
 		/* ed25519 public key */
 		resp->node.public_key.bytes[0] = 0;
 	}
-	resp->has_xpub = true;
 
+	resp->has_xpub = true;
 	if (coin->xpub_magic && (script_type == InputScriptType_SPENDADDRESS || script_type == InputScriptType_SPENDMULTISIG)) {
 		hdnode_serialize_public(node, fingerprint, coin->xpub_magic, resp->xpub, sizeof(resp->xpub));
 	} else

--- a/firmware/fsm_msg_debug.h
+++ b/firmware/fsm_msg_debug.h
@@ -49,7 +49,8 @@ void fsm_msgDebugLinkGetState(const DebugLinkGetState *msg)
 	resp.has_recovery_word_pos = true;
 	resp.recovery_word_pos = recovery_get_word_pos();
 
-	resp.has_mnemonic = config_getMnemonic(resp.mnemonic, sizeof(resp.mnemonic));
+	resp.has_mnemonic_secret = config_getMnemonicBytes(resp.mnemonic_secret.bytes, sizeof(resp.mnemonic_secret.bytes), &resp.mnemonic_secret.size);
+	resp.mnemonic_type = 0;  // BIP-39
 
 	resp.has_node = config_dumpNode(&(resp.node));
 

--- a/firmware/protob/Makefile
+++ b/firmware/protob/Makefile
@@ -26,7 +26,7 @@ messages_%_pb2.py: messages-%.proto
 	$(Q)protoc -I/usr/include -I. $< --python_out=.
 
 messages_map.h messages_map_limits.h: messages_map.py messages_pb2.py
-	$(Q)$(PYTHON) $< Cardano Tezos Ripple Monero DebugMonero Ontology Tron Eos
+	$(Q)$(PYTHON) $< Cardano Tezos Ripple Monero DebugMonero Ontology Tron Eos Binance
 
 clean:
 	rm -f *.pb *.o *.d *.pb.c *.pb.h *_pb2.py messages_map.h messages_map_limits.h

--- a/firmware/protob/messages-debug.options
+++ b/firmware/protob/messages-debug.options
@@ -3,7 +3,7 @@ DebugLinkDecision.input                 max_size:33
 DebugLinkState.layout                   max_size:1024
 DebugLinkState.pin                      max_size:10
 DebugLinkState.matrix                   max_size:10
-DebugLinkState.mnemonic                 max_size:241
+DebugLinkState.mnemonic_secret          max_size:240
 DebugLinkState.reset_word               max_size:12
 DebugLinkState.reset_entropy            max_size:128
 DebugLinkState.recovery_fake_word       max_size:12


### PR DESCRIPTION
1. fixes tests with current trezor-common (there was a missing `set_node` flag because of https://github.com/trezor/trezor-common/commit/84f5a0e39376409863c58a9ede1b61403306894b)
2. introduces option to return mnemonic as bytes because debuglink now returns bytes (https://github.com/trezor/trezor-common/commit/c5e54d7535c8772b9a75ff90c506a28526f94267)