### PR TITLE
Parse OMNI transactions as big-endian

### DIFF
--- a/firmware/layout2.c
+++ b/firmware/layout2.c
@@ -360,19 +360,19 @@ void layoutConfirmOmni(const uint8_t *data, uint32_t size) {
   if (tx_type == 0x00000000 && size == 20) {  // OMNI simple send
     desc = _("Simple send of ");
     REVERSE32(*(const uint32_t *)(data + 8), currency);
-    const char *suffix = "UNKN";
+    const char *suffix = " UNKN";
     switch (currency) {
       case 1:
-        suffix = "OMNI";
+        suffix = " OMNI";
         break;
       case 2:
-        suffix = "tOMNI";
+        suffix = " tOMNI";
         break;
       case 3:
-        suffix = "MAID";
+        suffix = " MAID";
         break;
       case 31:
-        suffix = "USDT";
+        suffix = " USDT";
         break;
     }
     uint64_t amount_be, amount;

--- a/firmware/layout2.c
+++ b/firmware/layout2.c
@@ -355,10 +355,11 @@ void layoutConfirmOutput(const CoinInfo *coin, const TxOutputType *out) {
 void layoutConfirmOmni(const uint8_t *data, uint32_t size) {
   const char *desc;
   char str_out[32];
-  const uint32_t tx_type = *(const uint32_t *)(data + 4);
+  uint32_t tx_type, currency;
+  REVERSE32(*(const uint32_t *)(data + 4), tx_type);
   if (tx_type == 0x00000000 && size == 20) {  // OMNI simple send
     desc = _("Simple send of ");
-    const uint32_t currency = *(const uint32_t *)(data + 8);
+    REVERSE32(*(const uint32_t *)(data + 8), currency);
     const char *suffix = "UNKN";
     switch (currency) {
       case 1:
@@ -374,8 +375,9 @@ void layoutConfirmOmni(const uint8_t *data, uint32_t size) {
         suffix = "USDT";
         break;
     }
-    uint64_t amount;
-    memcpy(&amount, data + 12, sizeof(uint64_t));
+    uint64_t amount_be, amount;
+    memcpy(&amount_be, data + 12, sizeof(uint64_t));
+    REVERSE64(amount_be, amount);
     bn_format_uint64(amount, NULL, suffix, BITCOIN_DIVISIBILITY, 0, false,
                      str_out, sizeof(str_out));
   } else {


### PR DESCRIPTION
fixes #469

reproducer `trezorctl sign-tx omni-test.json` with the following:
```json
{
  "inputs": [
    {
      "address_n": [2147483692, 2147483648, 2147483649, 999, 0],
      "script_type": 3,
      "prev_index": 2,
      "prev_hash": "e4d07ba87913e32cbacc5456f70149973dc374efc224ae7db078016af5d17f37",
      "amount": 546
    },
    {
      "address_n": [2147483692, 2147483648, 2147483649, 999, 0],
      "script_type": 3,
      "prev_index": 0,
      "prev_hash": "48bc377a3914ff07af7e3da926053913c0515943171ae0cfc15c943cd75ea15b",
      "amount": 914974
    }
  ],
  "outputs": [
    {
      "amount": 914974,
      "address_n": [2147483692, 2147483648, 2147483649, 0, 0],
      "script_type": 4
    },
    {
      "amount": 546,
      "address": "12eXXt156hevSx14c7pgryQcGLiPBFcPMj",
      "script_type": 0
    },
    {
      "amount": 0,
      "op_return_data": "6f6d6e69000000000000001f000000001dcd6500",
      "script_type": 3
    }
  ],
  "coin_name": "Bitcoin",
  "prev_txes": {},
  "details": {}
}
```